### PR TITLE
Feat rag

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The **UI Extension** provides the user-facing chat interface within the Rancher 
 
 ## How It Works (Flow)
 
-1. **User Request → LLM**  
+1. **User Request → Agent → LLM**  
    The user submits a natural language query through the UI Extension.  
 2. **LLM Reasoning**  
    The LLM interprets the request, reasons about the problem, and proposes a plan.  

--- a/agents/__init__.py
+++ b/agents/__init__.py
@@ -1,2 +1,3 @@
 from .k8s import create_k8s_agent
 from .k8s import Context
+from .k8s import init_rag_rancher

--- a/agents/k8s.py
+++ b/agents/k8s.py
@@ -1,3 +1,4 @@
+import os
 from typing import (
     Annotated,
     Sequence,
@@ -11,6 +12,11 @@ from langchain_core.tools import BaseTool, ToolException
 from langgraph.graph import StateGraph, END
 from langgraph.graph.state import CompiledStateGraph
 from langchain_core.language_models.chat_models import BaseChatModel
+from langchain_core.vectorstores import InMemoryVectorStore, VectorStoreRetriever
+from langchain.document_loaders import DirectoryLoader
+from langchain_text_splitters import RecursiveCharacterTextSplitter
+from langchain_core.embeddings import Embeddings
+
 from langgraph.runtime import Runtime
 import langgraph.types 
 from dataclasses import dataclass
@@ -25,7 +31,37 @@ class AgentState(TypedDict):
     """The state of the agent."""
     messages: Annotated[Sequence[BaseMessage], add_messages]
 
+def init_rag_rancher(embedding_model: Embeddings) -> VectorStoreRetriever:
+    """
+    Creates a retriever for Rancher documentation using RAG (Retrieval-Augmented Generation).
 
+    Args:
+        embedding_model: The embedding model to use for creating document embeddings.
+
+    Returns:
+        A VectorStoreRetriever that can be used to fetch relevant documents.
+    """
+    # test if `/rancher_docs` exists and contains files
+    doc_path = os.environ.get("DOCS_PATH", "/rancher_docs")
+    if not os.path.exists(doc_path) or not os.listdir(doc_path):
+        raise FileNotFoundError("The directory /rancher_docs does not exist or is empty.")
+    # load all markdown files in the directory
+    loader = DirectoryLoader(doc_path, glob="**/*.md")
+    docs = loader.load()
+    print(f"→ {len(docs)} raw documents loaded")
+    # 
+    text_splitter = RecursiveCharacterTextSplitter(
+        chunk_size=1000,  # chunk size (characters)
+        chunk_overlap=200,  # chunk overlap (characters)
+        add_start_index=True,  # track index in original document
+    )
+    all_splits = text_splitter.split_documents(docs)
+    # Initialize the vector store
+    vector_store = InMemoryVectorStore(embedding_model)  
+    vector_store.add_documents(documents=all_splits)
+    retriever = vector_store.as_retriever(search_kwargs={"k": 6})
+    return retriever
+    
 def create_k8s_agent(llm: BaseChatModel, tools: list[BaseTool], system_prompt: str) -> CompiledStateGraph:
     """
     Creates a LangGraph agent capable of interacting with Kubernetes resources.
@@ -38,7 +74,7 @@ def create_k8s_agent(llm: BaseChatModel, tools: list[BaseTool], system_prompt: s
     Returns:
         A compiled LangGraph StateGraph ready to be invoked.
     """
-
+    
     llm_with_tools = llm.bind_tools(tools)
 
     def should_interrupt(tool_call: any) -> str:

--- a/agents/k8s.py
+++ b/agents/k8s.py
@@ -33,6 +33,7 @@ class Context:
 class AgentState(TypedDict):
     """The state of the agent."""
     messages: Annotated[Sequence[BaseMessage], add_messages]
+    summary: str
 
 def init_rag_rancher(embedding_model: Embeddings) -> VectorStoreRetriever:
     """

--- a/chart/templates/ai-agent-deployment.yaml
+++ b/chart/templates/ai-agent-deployment.yaml
@@ -49,5 +49,15 @@ spec:
               secretKeyRef:
                 name: llm-config
                 key: SYSTEM_PROMPT
+          - name: ENABLE_RAG
+            valueFrom:
+              secretKeyRef:
+                name: llm-config
+                key: ENABLE_RAG
+          - name: EMBEDDINGS_MODEL
+            valueFrom:
+              secretKeyRef:
+                name: llm-config
+                key: EMBEDDINGS_MODEL
         ports:
          - containerPort: 8000

--- a/chart/templates/llm-config.yaml
+++ b/chart/templates/llm-config.yaml
@@ -10,3 +10,5 @@ stringData:
   MODEL: "{{ .Values.llmModel }}"
   OLLAMA_URL: "{{ .Values.ollamaUrl }}"
   GOOGLE_API_KEY: "{{ .Values.googleApiKey }}"
+  ENABLE_RAG: "{{ .Values.rag.enabled }}"
+  EMBEDDINGS_MODEL: "{{ .Values.rag.embeddings_model }}"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -17,7 +17,7 @@ googleApiKey:
 openaiApiKey:
 # Enable RAG with embedded rancher documentation
 rag:
-    enabled: true
+    enabled: false
     # Select an embeddings model from https://python.langchain.com/docs/integrations/text_embedding/#all-embedding-models
     # OpenAI example: "text-embedding-3-large"
     # Gemini example: "models/gemini-embedding-001"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1,18 +1,18 @@
 aiAgent:
   image:
-    repository: jpgouin/rancher-ai-agent
-    tag: v1-rc12
-    pullPolicy: Always
+    repository: ghcr.io/rancher-sandbox/rancher-ai-agent
+    tag: v0.0.1-alpha.6
+    pullPolicy: IfNotPresent
 mcp:
   image:
-    repository: jpgouin/rancher-ai-mcp
-    tag: v1
-    pullPolicy: Always
+    repository: ghcr.io/rancher-sandbox/rancher-ai-mcp
+    tag: v0.0.1-alpha.6
+    pullPolicy: IfNotPresent
 
 imagePullSecrets: [] # Default to an empty list
 
-llmModel: "qwen3:8b"
-ollamaUrl: "https://42720c58b137.ngrok.app"
+llmModel: ""
+ollamaUrl: ""
 googleApiKey:
 openaiApiKey:
 # Enable RAG with embedded rancher documentation

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1,17 +1,24 @@
 aiAgent:
   image:
-    repository: ghcr.io/rancher-sandbox/rancher-ai-agent
-    tag: v0.0.1-alpha.6
-    pullPolicy: IfNotPresent
+    repository: jpgouin/rancher-ai-agent
+    tag: v1-rc12
+    pullPolicy: Always
 mcp:
   image:
-    repository: ghcr.io/rancher-sandbox/rancher-ai-mcp
-    tag: v0.0.1-alpha.6
-    pullPolicy: IfNotPresent
+    repository: jpgouin/rancher-ai-mcp
+    tag: v1
+    pullPolicy: Always
 
 imagePullSecrets: [] # Default to an empty list
 
-llmModel:
-ollamaUrl:
+llmModel: "qwen3:8b"
+ollamaUrl: "https://42720c58b137.ngrok.app"
 googleApiKey:
 openaiApiKey:
+# Enable RAG with embedded rancher documentation
+rag:
+    enabled: true
+    # Select an embeddings model from https://python.langchain.com/docs/integrations/text_embedding/#all-embedding-models
+    # OpenAI example: "text-embedding-3-large"
+    # Gemini example: "models/gemini-embedding-001"
+    embeddings_model: "qwen3-embedding:0.6b"

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,6 +1,42 @@
-#TODO improve this
+# =================================================================
+# Stage 1: Build the documentation artifact
+# This stage uses a lightweight image (alpine) to download, extract,
+# and isolate the required documentation folders. The output of this
+# stage is a clean /rancher_docs directory that we can copy later.
+# =================================================================
+FROM alpine:latest AS docs-builder
+
+ARG DOCS_URL=https://github.com/rancher/rancher-docs/archive/refs/tags/initial-snapshot-v2.12.2.tar.gz
+LABEL stage="docs-builder"
+WORKDIR /tmp/src
+
+RUN apk add --no-cache wget && \
+    wget -O rancher-docs.tar.gz ${DOCS_URL} && \
+    tar -xvzf rancher-docs.tar.gz --strip-components=1
+
+RUN mkdir /rancher_docs && \
+    mv /tmp/src/docs/troubleshooting /rancher_docs/ && \
+    mv /tmp/src/docs/reference-guides /rancher_docs/
+
+#TODO - add more documentation as needed
+#TODO - add RAG data cleanup
+
+# =================================================================
+# Stage 2: Build the final application image
+# This stage uses the Python base image, copies your application code,
+# installs runtime dependencies, and copies the prepared documentation
+# artifact from the first stage.
+# =================================================================
 FROM registry.suse.com/bci/python:3.12
+
+# Set the working directory for the application
 WORKDIR /app
+
 COPY . .
+
 RUN pip install uv
-CMD ["uv" ,"run", "fastapi", "run"]
+
+COPY --from=docs-builder /rancher_docs /rancher_docs
+
+# Specify the default command to run when the container starts
+CMD ["uv", "run", "fastapi", "run"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,8 @@ dependencies = [
     "langchain-mcp-adapters>=0.1.9",
     "langchain-ollama>=0.3.6",
     "langchain-openai>=0.3.33",
+    "langchain-text-splitters>=0.3.11",
+    "langchain-community>=0.3.30",
     "langfuse>=3.3.4",
     "langgraph>=0.6.4",
     "langgraph-supervisor>=0.0.29",
@@ -19,4 +21,6 @@ dependencies = [
     "mock>=5.2.0",
     "pytest>=8.4.2",
     "pytest-asyncio>=1.2.0",
+    "unstructured>=0.18.15",
+    "unstructured[md]>=0.18.15"
 ]


### PR DESCRIPTION
Add RAG support into the Agent
Currently it parses a limited amount of documentation provided through the building phase. 
- docs/troubleshooting
- docs/reference-guides

This should help the model to hallucinate less and provide more accurate answers.

This feature is `disabled` by default. 
Enabling it requires a `embeddings_model` to provide in the `values.yaml`
