### PR TITLE
Allow AIAgentConfigs `list` and `get`

### DIFF
--- a/chart/agent/templates/cert/agent-sa.yaml
+++ b/chart/agent/templates/cert/agent-sa.yaml
@@ -22,7 +22,7 @@ rules:
   resourceNames: ["rancher-ai-agent"]
 - apiGroups: ["ai.cattle.io"]
   resources: ["aiagentconfigs"]
-  verbs: ["create"]
+  verbs: ["create", "list", "get"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding


### PR DESCRIPTION
This fixes errors getting the aiagentconfigs list on fresh installation:

```
{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"aiagentconfigs.ai.cattle.io is forbidden: User \"system:serviceaccount:cattle-ai-agent-system:agent-sa\" cannot list resource \"aiagentconfigs\" in API group \"ai.cattle.io\" in the namespace \"cattle-ai-agent-system\"","reason":"Forbidden","details":{"group":"ai.cattle.io","kind":"aiagentconfigs"},"code":403}
2026-01-26 21:45:26,401 - root - ERROR - Failed to list AIAgentConfig: (403)
```