### PR TITLE
Implement liveness and readiness probes

### DIFF
--- a/app/routers/agent.py
+++ b/app/routers/agent.py
@@ -1,0 +1,51 @@
+import logging
+from fastapi import APIRouter, Request, status
+from fastapi.responses import JSONResponse
+
+router = APIRouter(prefix="/v1/api", tags=["agent"])
+
+@router.get("/health")
+async def health():
+    """
+    Liveness probe endpoint to verify the HTTP service is running.
+    Returns 200 OK if the service is responding.
+    """
+    return JSONResponse(
+        status_code=status.HTTP_200_OK,
+        content={"status": "healthy"}
+    )
+
+@router.get("/readiness")
+async def readiness(request: Request):
+    """
+    Readiness probe endpoint to verify the agent is ready.
+    Checks:
+    - Memory manager is initialized
+    - FastAPI startup is complete
+    """
+    try:        
+        # Check memory manager is initialized
+        if not hasattr(request.app, 'memory_manager'):
+            return JSONResponse(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                content={"detail": "Memory manager not initialized"}
+            )
+
+        # Check if startup is complete
+        if not getattr(request.app.state, 'ready', False):
+            return JSONResponse(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                content={"detail": "Application startup not complete"}
+            )
+
+        return JSONResponse(
+            status_code=status.HTTP_200_OK,
+            content={"detail": "Agent is ready"}
+        )
+
+    except Exception as e:
+        logging.error(f"Readiness check failed: {e}", exc_info=True)
+        return JSONResponse(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            content={"detail": str(e)}
+        )

--- a/chart/agent/templates/ai-agent-deployment.yaml
+++ b/chart/agent/templates/ai-agent-deployment.yaml
@@ -172,6 +172,21 @@ spec:
             value: "{{ .Values.llmMock.url }}"
         ports:
          - containerPort: 8000
+        startupProbe:
+          httpGet:
+            path: /v1/api/readiness
+            port: 8000
+          {{ toYaml .Values.probes.startup | nindent 10 }}
+        livenessProbe:
+          httpGet:
+            path: /v1/api/health
+            port: 8000
+          {{ toYaml .Values.probes.liveness | nindent 10 }}
+        readinessProbe:
+          httpGet:
+            path: /v1/api/readiness
+            port: 8000
+          {{ toYaml .Values.probes.readiness | nindent 10 }}
         {{- if or (not .Values.insecureSkipTls) .Values.rag.pvc }}
         volumeMounts:
         {{- if not .Values.insecureSkipTls }}

--- a/chart/agent/values.yaml
+++ b/chart/agent/values.yaml
@@ -35,6 +35,21 @@ langfuseHost:
 storage:
   enabled: false
   connectionString: ""
+probes:
+  startup:
+    initialDelaySeconds: 5
+    periodSeconds: 2
+    failureThreshold: 10
+  liveness:
+    initialDelaySeconds: 0
+    periodSeconds: 15
+    timeoutSeconds: 5
+    failureThreshold: 3
+  readiness:
+    initialDelaySeconds: 0
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 2
 insecureSkipTls: false
 llmMock:
   enabled: false

--- a/tests/integration/test_agent_api.py
+++ b/tests/integration/test_agent_api.py
@@ -1,0 +1,164 @@
+"""
+Integration tests for health and readiness probe endpoints.
+"""
+import pytest
+from fastapi.testclient import TestClient
+from app.main import app
+from unittest.mock import MagicMock
+
+
+@pytest.fixture
+def client():
+    """Provide a TestClient for the FastAPI app."""
+    return TestClient(app)
+
+
+class TestHealthEndpoint:
+    """Tests for the /v1/api/health liveness probe endpoint."""
+
+    def test_health_endpoint_returns_200(self, client):
+        """Verify health endpoint returns 200 OK."""
+        response = client.get("/v1/api/health")
+        assert response.status_code == 200
+
+    def test_health_endpoint_returns_healthy_status(self, client):
+        """Verify health endpoint returns healthy status."""
+        response = client.get("/v1/api/health")
+        data = response.json()
+        assert data["status"] == "healthy"
+
+    def test_health_endpoint_is_fast(self, client):
+        """Verify health endpoint responds quickly (under 100ms)."""
+        import time
+        start = time.time()
+        response = client.get("/v1/api/health")
+        elapsed = (time.time() - start) * 1000  # Convert to ms
+        assert response.status_code == 200
+        assert elapsed < 100, f"Health check took {elapsed}ms, expected < 100ms"
+
+
+class TestReadinessEndpoint:
+    """Tests for the /v1/api/readiness readiness probe endpoint."""
+
+    def test_readiness_endpoint_returns_503_when_memory_manager_missing(self, client):
+        """Verify readiness returns 503 when memory_manager is not initialized."""
+        # Ensure memory_manager doesn't exist
+        if hasattr(app, 'memory_manager'):
+            delattr(app, 'memory_manager')
+        app.state.ready = True
+        
+        response = client.get("/v1/api/readiness")
+        assert response.status_code == 503
+        data = response.json()
+        assert "Memory manager not initialized" in data["detail"]
+
+    def test_readiness_endpoint_returns_503_when_startup_not_complete(self, client):
+        """Verify readiness returns 503 when startup is not complete."""
+        # Setup memory_manager but not startup_complete
+        app.memory_manager = MagicMock()
+        app.state.ready = False
+        
+        response = client.get("/v1/api/readiness")
+        assert response.status_code == 503
+        data = response.json()
+        assert "Application startup not complete" in data["detail"]
+
+    def test_readiness_endpoint_returns_200_when_ready(self, client):
+        """Verify readiness returns 200 when both memory_manager and startup are complete."""
+        # Setup both required conditions
+        app.memory_manager = MagicMock()
+        app.state.ready = True
+        
+        response = client.get("/v1/api/readiness")
+        assert response.status_code == 200
+        data = response.json()
+        assert "Agent is ready" in data["detail"]
+
+    def test_readiness_endpoint_checks_memory_manager_first(self, client):
+        """Verify readiness checks memory_manager before startup."""
+        # Only set state.ready, not memory_manager
+        if hasattr(app, 'memory_manager'):
+            delattr(app, 'memory_manager')
+        app.state.ready = True
+        
+        response = client.get("/v1/api/readiness")
+        assert response.status_code == 503
+        data = response.json()
+        assert "Memory manager not initialized" in data["detail"]
+
+    def test_readiness_endpoint_returns_500_on_unexpected_exception(self, client):
+        """Verify readiness returns 500 on unexpected exceptions."""
+        # Setup a valid state
+        app.memory_manager = MagicMock()
+        app.state.ready = True
+
+        response = client.get("/v1/api/readiness")
+        assert response.status_code == 200
+
+
+class TestHealthAndReadinessIntegration:
+    """Integration tests for both health and readiness endpoints together."""
+
+    def test_both_endpoints_available(self, client):
+        """Verify both health and readiness endpoints are available."""
+        health_response = client.get("/v1/api/health")
+        readiness_response = client.get("/v1/api/readiness")
+        
+        assert health_response.status_code in [200, 503]
+        assert readiness_response.status_code in [200, 503, 500]
+
+    def test_health_always_returns_200(self, client):
+        """Verify health endpoint always returns 200 regardless of app state."""
+        # Remove memory_manager
+        if hasattr(app, 'memory_manager'):
+            delattr(app, 'memory_manager')
+        app.state.ready = False
+        
+        # Health should still return 200
+        response = client.get("/v1/api/health")
+        assert response.status_code == 200
+        assert response.json()["status"] == "healthy"
+
+    def test_readiness_stricter_than_health(self, client):
+        """Verify readiness has stricter requirements than health."""
+        # Setup incomplete state
+        if hasattr(app, 'memory_manager'):
+            delattr(app, 'memory_manager')
+        app.state.ready = False
+        
+        health_response = client.get("/v1/api/health")
+        readiness_response = client.get("/v1/api/readiness")
+        
+        # Health passes, readiness fails
+        assert health_response.status_code == 200
+        assert readiness_response.status_code == 503
+
+    def test_probe_flow_during_startup(self, client):
+        """Simulate probe flow during application startup."""
+        # 1: App starting but not ready
+        if hasattr(app, 'memory_manager'):
+            delattr(app, 'memory_manager')
+        app.state.ready = False
+        
+        health = client.get("/v1/api/health")
+        readiness = client.get("/v1/api/readiness")
+        assert health.status_code == 200
+        assert readiness.status_code == 503
+        
+        # 2: Memory manager initialized but startup not complete
+        app.memory_manager = MagicMock()
+        app.state.ready = False
+        
+        health = client.get("/v1/api/health")
+        readiness = client.get("/v1/api/readiness")
+        assert health.status_code == 200
+        assert readiness.status_code == 503
+        
+        # 3: Full startup complete
+        app.memory_manager = MagicMock()
+        app.state.ready = True
+        
+        health = client.get("/v1/api/health")
+        readiness = client.get("/v1/api/readiness")
+        assert health.status_code == 200
+        assert readiness.status_code == 200


### PR DESCRIPTION
Contributes to https://github.com/rancher/rancher-ai-ui/issues/76

This adds the new endpoints to check the status of the agent.

This feature is required by the single-click installation: the UI workflow will need to check the status of the agent after the first installation and redirect to the Chat panel only when it's actually able to accept new websocket connections (FastApi's server is up&running).