### PR TITLE
Fix llm message content to support multiple formats

### DIFF
--- a/app/services/memory.py
+++ b/app/services/memory.py
@@ -341,7 +341,7 @@ class MemoryManager:
                     selected_agent = msg.additional_kwargs.get("selected_agent", selected_agent)
 
                     if msg.type == 'ai':
-                        llm_str = msg.content if msg.content else ""
+                        llm_str = msg.text if msg.text else ""
 
                     if msg.type == 'tool':
                         interrupt_str = msg.additional_kwargs.get("interrupt_message", "")


### PR DESCRIPTION
When the `llm` is not able fulfill the user's request, the `message.content` - which is the primitive returned message from the llm - has a not-consistent type, for instance an array of {{ "text": "string content"} object, plain string }.

<img width="1041" height="181" alt="Screenshot from 2026-02-11 19-49-46" src="https://github.com/user-attachments/assets/61e2c91d-b329-4f00-88ae-6fafbeffe83a" />

We need to switch to `message.text` - which is value parsed by LangGraph - when returning the list of messages in the memory service

@raulcabello `message.content` is used elsewhere in the code, should we consider to replace it ?