### PR TITLE
Fix routing when blank spaces are returned

### DIFF
--- a/app/services/agent/parent.py
+++ b/app/services/agent/parent.py
@@ -4,6 +4,7 @@ Parent agent implementation using LangGraph Command primitive for routing to spe
 This module provides a parent agent that uses an LLM to intelligently route user requests
 to the most appropriate specialized child agent based on the request content.
 """
+import logging
 from langchain_core.runnables import RunnableConfig
 from langgraph.graph import StateGraph, END
 from langgraph.graph.state import CompiledStateGraph, Checkpointer
@@ -16,15 +17,25 @@ from dataclasses import dataclass
 from .loader import DEFAULT_AGENT_NAME, AgentConfig
 from .base import BaseAgentBuilder, AgentState, build_agent_metadata
 
-SYSTEM_ROUTER_PROMPT = """You are a routing supervisor for a multi-agent system. Your job is to analyze the user's request and select the most appropriate child agent to handle it.
+def build_router_prompt(agent_names: list[str]) -> str:
+    """Build the system router prompt with the list of valid agent names.
+    
+    Args:
+        agent_names: List of valid agent names that can be selected
+        
+    Returns:
+        System prompt for routing requests to child agents
+    """
+    agents_list = ", ".join(f"'{name}'" for name in agent_names)
+    return f"""You are a routing supervisor for a multi-agent system. Your job is to analyze the user's request and select the most appropriate child agent to handle it.
 
 INSTRUCTIONS:
 1. Carefully analyze the user's request and intent
 2. Match the request to the child agent whose description best aligns with the user's needs
 3. Consider the full conversation context if available
-4. Respond with ONLY the exact name of the selected child agent (no explanations or extra text)
+4. Respond with ONLY the exact name of the selected child agent (no explanations or extra text). Valid agents are: {agents_list}
 5. You MUST choose exactly one agent - never return multiple names or explanations
-6. If the request is ambiguous or could match multiple agents, default to 'Rancher'
+6. If the request is ambiguous or could match multiple agents, default to 'rancher'
 
 """
 
@@ -104,17 +115,19 @@ class ParentAgentBuilder(BaseAgentBuilder):
         messages = state["messages"]
 
         # Build routing prompt with available child agents and their descriptions
-        router_prompt = SYSTEM_ROUTER_PROMPT + "AVAILABLE CHILD AGENTS:\n"
+        agent_names = [child.config.name for child in self.child_agents]
+        router_prompt = build_router_prompt(agent_names) + "AVAILABLE CHILD AGENTS:\n"
         for child in self.child_agents:
             router_prompt += f"- {child.config.name}: {child.config.description}\n"
-        router_prompt += f"\nUSER'S REQUEST: {messages[-1].content}\n"
+        router_prompt += f"\nUSER'S REQUEST: {messages[-1].content}"
         
         user_and_ai_messages = [msg for msg in self._get_messages_from_last_summary(state) if isinstance(msg, (HumanMessage, AIMessage, SystemMessage))]
 
         # Use LLM to select the appropriate child agent
-        child_agent = self.llm.invoke([SystemMessage(content=router_prompt)] + user_and_ai_messages).content
+        child_agent = self.llm.invoke([SystemMessage(content=router_prompt)] + user_and_ai_messages).text.strip()
         if child_agent not in [child.config.name for child in self.child_agents]:
             # Fallback to default agent if the agent selection from LLM is invalid
+            logging.warning(f"LLM selected invalid agent '{child_agent}', defaulting to '{DEFAULT_AGENT_NAME}'")
             child_agent = DEFAULT_AGENT_NAME
 
         self.agent_selected = child_agent


### PR DESCRIPTION
This PR fixes a problem when gemini 2.0 flash returned the choosen agent with balnk spaces.
It also fixes a problem with gemini 3.0 preview as content of the invoke response it now returns more than just text.