### PR TITLE
Nit - improve agent validations error to be consumed by the UI

### DIFF
--- a/app/routers/websocket.py
+++ b/app/routers/websocket.py
@@ -63,7 +63,7 @@ async def websocket_endpoint(websocket: WebSocket, thread_id: str = None, llm: B
         agent, agents_metadata =  await create_agent(llm=llm, websocket=websocket) 
     except NoAgentAvailableError as e:
         logging.error(f"Error creating agent: {e}")
-        await websocket.send_text(f'<error>{{"message": "{str(e)}"}}</error>')
+        await websocket.send_text(f'<chat-error>{{"message": "{str(e)}"}}</chat-error>')
         await websocket.close()
         return
 

--- a/app/services/agent/factory.py
+++ b/app/services/agent/factory.py
@@ -205,8 +205,8 @@ async def _create_single_agent(
         _update_agent_status(agent_cfg, False, 'MCPConnectionFailed', f"Failed to load MCP tools: {error_message}")
         
         raise NoAgentAvailableError(
-            f"Failed to load MCP tools for agent '{agent_cfg.name}'. "
-            f"Please check the MCP server connection and configuration. Error details: {error_message}"
+            f"Failed to load MCP tools for all enabled agents.\\n"
+            f"Please check the AI Agents configuration and ensure the MCP server is accessible with the provided connection details."
         )
 
     return create_root_agent(llm, tools, agent_cfg.system_prompt, checkpointer, agent_cfg)


### PR DESCRIPTION
Some small fixes:

- `<chat-error>` tag allows to differentiate messages error and chat errors in the UI
- when `agent_cfg.name` is None, the error message is not a valid JSON - We are simplifying the generated string.