### PR TITLE
Remove the logic to select the Active LLM

### DIFF
--- a/app/services/llm.py
+++ b/app/services/llm.py
@@ -36,41 +36,31 @@ class LLMManager:
 def get_llm() -> BaseLanguageModel:
     """
     Selects and returns a language model instance based on environment variables.
-    - If an active LLM is specified, it prioritizes that model; otherwise, it checks for available configurations in a predefined order.
-    - If no supported model or API key is found, it raises a ValueError.
+    - If the active LLM or the model is not configured, it raises a ValueError.
     - If LLM mocking is enabled, it configures the connections to the mock server.
     
     Returns:
         An instance of a language model.
         
     Raises:
-        ValueError: If no supported model or API key is configured.
+        ValueError: If the active LLM or the model is not configured.
     """
 
-    active = os.environ.get("ACTIVE_LLM", "")
-    
-    if active:
-        if active in ["ollama", "gemini", "openai", "bedrock"]:
-            model = get_llm_model(active)
-        else:
-            raise ValueError("Unsupported Active LLM specified.")
+    activeLlm = get_active_llm()
+    model = get_llm_model(activeLlm)
     
     llm_mock_enabled = os.environ.get("LLM_MOCK_ENABLED", "false").lower() == "true"
     llm_mock_url = os.environ.get("LLM_MOCK_URL", "")
-    if active and llm_mock_enabled:
+    if llm_mock_enabled:
         logging.info(f"Connecting to LLM Mock server at {llm_mock_url}")
-    
-    ollama_url = os.environ.get("OLLAMA_URL")
-    gemini_key = os.environ.get("GOOGLE_API_KEY")
-    openai_key = os.environ.get("OPENAI_API_KEY")
-    openai_url = os.environ.get("OPENAI_URL")
-    aws_region = os.environ.get("AWS_REGION")
 
-    if active == "ollama":
+    if activeLlm == "ollama":
         if llm_mock_enabled:
             return ChatOllama(model=model, base_url=llm_mock_url)
+
+        ollama_url = os.environ.get("OLLAMA_URL")
         return ChatOllama(model=model, base_url=ollama_url)
-    if active == "gemini":
+    if activeLlm == "gemini":
         if llm_mock_enabled:
             return ChatGoogleGenerativeAI(
                 model=model,
@@ -78,35 +68,32 @@ def get_llm() -> BaseLanguageModel:
                 transport="rest"
             )
         return ChatGoogleGenerativeAI(model=model)
-    if active == "openai":
+    if activeLlm == "openai":
         if llm_mock_enabled:
             return ChatOpenAI(model=model, base_url=llm_mock_url)
+        
+        openai_url = os.environ.get("OPENAI_URL")
         if openai_url:
             return ChatOpenAI(model=model, base_url=openai_url)
         return ChatOpenAI(model=model)
-    if active == "bedrock":
+    if activeLlm == "bedrock":
         if llm_mock_enabled:
             os.environ["AWS_ENDPOINT_URL"] = llm_mock_url
         return ChatBedrockConverse(model=model)
 
-    # default order if active is not specified
-    if ollama_url:
-        model = get_llm_model("ollama")
-        return ChatOllama(model=model, base_url=ollama_url)
-    if gemini_key:
-        model = get_llm_model("gemini")
-        return ChatGoogleGenerativeAI(model=model)
-    if openai_key:
-        model = get_llm_model("openai")
-        if openai_url:
-            return ChatOpenAI(model=model, base_url=openai_url)
-        else:
-            return ChatOpenAI(model=model)
-    if aws_region:
-        model = get_llm_model("bedrock")
-        return ChatBedrockConverse(model=model)
+def get_active_llm() -> str:
+    """
+    Retrieves the active LLM identifier from environment variables.
+    
+    Returns:
+        The active LLM as a string, or None if not set.
+    """
+    llm = os.environ.get("ACTIVE_LLM", "")
+    
+    if llm not in ["ollama", "gemini", "openai", "bedrock"]:
+        raise ValueError("LLM not configured.")
 
-    raise ValueError("LLM not configured.")
+    return llm
 
 def get_llm_model(llm: str) -> str:
     """

--- a/tests/unit/services/test_llm.py
+++ b/tests/unit/services/test_llm.py
@@ -5,6 +5,8 @@ from fastapi import WebSocketDisconnect
 
 from app.services.llm import (
     get_llm,
+    get_active_llm,
+    get_llm_model,
 )
 
 @patch('app.services.llm.ChatOllama')
@@ -28,20 +30,21 @@ def test_get_llm_openai(mock_openai):
         mock_openai.assert_called_once_with(model="gpt-4")
         assert llm == mock_openai.return_value
 
-def test_get_llm_no_model():
+def test_get_active_llm_not_configured():
     with patch.dict(os.environ, {}, clear=True):
         with pytest.raises(ValueError, match="LLM not configured."):
-            get_llm()
+            get_active_llm()
 
-def test_get_llm_no_provider():
-    with patch.dict(os.environ, {"OLLAMA_MODEL": "some-model"}, clear=True):
+def test_get_active_llm_invalid():
+    with patch.dict(os.environ, {"ACTIVE_LLM": "invalid-llm"}, clear=True):
         with pytest.raises(ValueError, match="LLM not configured."):
-            get_llm()
-        
-def test_get_llm_invalid_active_model():
-    with patch.dict(os.environ, {"OLLAMA_MODEL": "some-model", "ACTIVE_LLM": "invalid-llm"}, clear=True):
-        with pytest.raises(ValueError, match="Unsupported Active LLM specified."):
-            get_llm()
+            get_active_llm()
+
+def test_get_llm_model_not_configured():
+    """Test get_llm_model when no model is configured for the active LLM"""
+    with patch.dict(os.environ, {"ACTIVE_LLM": "ollama"}, clear=True):
+        with pytest.raises(ValueError, match="LLM Model not configured"):
+            get_llm_model("ollama")
 
 @patch('app.services.llm.ChatOllama')
 def test_get_llm_with_mock(mock_chat_ollama):
@@ -70,4 +73,45 @@ def test_get_llm_without_mock(mock_chat_ollama):
         llm = get_llm()
         mock_chat_ollama.assert_called_once_with(model="test-model", base_url="http://localhost:11434")
         assert llm == mock_chat_ollama.return_value
+
+@patch('app.services.llm.ChatGoogleGenerativeAI')
+def test_get_llm_gemini_with_mock(mock_chat_gemini):
+    """Test that mock URL is used for Gemini when LLM_MOCK_ENABLED is true"""
+    with patch.dict(os.environ, {
+        "GEMINI_MODEL": "gemini-pro",
+        "ACTIVE_LLM": "gemini",
+        "GOOGLE_API_KEY": "fake-key",
+        "LLM_MOCK_ENABLED": "true",
+        "LLM_MOCK_URL": "http://mock-server:8000"
+    }, clear=True):
+        llm = get_llm()
+        mock_chat_gemini.assert_called_once_with(model="gemini-pro", base_url="http://mock-server:8000", transport="rest")
+        assert llm == mock_chat_gemini.return_value
+
+@patch('app.services.llm.ChatOpenAI')
+def test_get_llm_openai_with_mock(mock_openai):
+    """Test that mock URL is used for OpenAI when LLM_MOCK_ENABLED is true"""
+    with patch.dict(os.environ, {
+        "OPENAI_MODEL": "gpt-4",
+        "ACTIVE_LLM": "openai",
+        "OPENAI_API_KEY": "fake-key",
+        "LLM_MOCK_ENABLED": "true",
+        "LLM_MOCK_URL": "http://mock-server:8000"
+    }, clear=True):
+        llm = get_llm()
+        mock_openai.assert_called_once_with(model="gpt-4", base_url="http://mock-server:8000")
+        assert llm == mock_openai.return_value
+
+@patch('app.services.llm.ChatOpenAI')
+def test_get_llm_openai_with_custom_url(mock_openai):
+    """Test that custom OPENAI_URL is used when provided"""
+    with patch.dict(os.environ, {
+        "OPENAI_MODEL": "gpt-4",
+        "ACTIVE_LLM": "openai",
+        "OPENAI_API_KEY": "fake-key",
+        "OPENAI_URL": "http://custom-openai:8000"
+    }, clear=True):
+        llm = get_llm()
+        mock_openai.assert_called_once_with(model="gpt-4", base_url="http://custom-openai:8000")
+        assert llm == mock_openai.return_value
 


### PR DESCRIPTION
We are removing the logic to decode the active llm based on Provider's API key  and URL, and forcing the use of ACTIVE_LLM.
This also allow to remove the decode logic from the UI as well and get the active llm name directly from the `llm-config` ConfigMap -> no need to fetch the `llm-secret`  secret -> no secret's permissions required by standard users.