### PR TITLE
Add provisioning tools to human validation

### DIFF
--- a/app/services/agent/loader.py
+++ b/app/services/agent/loader.py
@@ -208,7 +208,8 @@ def _create_default_ai_agent_config_crds(api: client.CustomObjectsApi):
                     "createProject",
                     "createImportedCluster",
                     "createImportedCluster",
-                    "scaleClusterNodePool"
+                    "scaleClusterNodePool",
+                    "createK3kCluster",
                 ]
             }
         }


### PR DESCRIPTION
`createk3kcluster`, `createImportedCluster`, `createImportedCluster` and `scaleClusterNodePool` requires human validation. 
 More info https://github.com/rancher/rancher-ai-mcp/pull/30