### PR TITLE
Fix duplicate tool executions with multiple interrupts

### DIFF
--- a/app/services/agent/base.py
+++ b/app/services/agent/base.py
@@ -17,6 +17,7 @@ from .loader import AgentConfig
 from .state import AgentState
 
 INTERRUPT_CANCEL_MESSAGE = "tool execution cancelled by the user"
+INTERRUPT_PREVIOUS_TOOL_FAILED_MESSAGE = "tool execution cancelled because previous tool call failed"
 
 class BaseAgentBuilder:
     """Base class for agent builders with shared logic."""
@@ -195,28 +196,49 @@ You are a highly specialized Assistant. Your primary goal is to provide accurate
         
         request_id = config["configurable"]["request_id"]
 
-        for tool_call in getattr(state["messages"][-1], "tool_calls", []):
-            should_continue, interrupt_message = await self.handle_interrupt(getattr(self.agent_config, "human_validation_tools", []), tool_call, state)
+        tool_calls = getattr(state["messages"][-1], "tool_calls", [])
+        human_validation_tools = getattr(self.agent_config, "human_validation_tools", [])
 
+        # Phase 1: Resolve all interrupt decisions before executing any tools.
+        # langgraph replays the entire node on resume after an interrupt, so if
+        # interrupts and tool executions are interleaved, tools that ran before a
+        # later interrupt would be re-invoked on replay.  Collecting all interrupt
+        # responses first ensures every tool is executed exactly once.
+        interrupt_messages = {}
+        for idx, tool_call in enumerate(tool_calls):
+            should_continue, interrupt_message = await self.handle_interrupt(human_validation_tools, tool_call, state)
+            if not should_continue:
+                # Cancel ALL tool calls: previously approved ones, the rejected one,
+                # and any remaining unevaluated ones — no tools will be executed.
+                outputs = self._cancel_remaining_tool_calls(tool_calls[:idx], request_id, state, INTERRUPT_CANCEL_MESSAGE)
+                cancel_kwargs = {
+                    "request_id": request_id,
+                    "selected_agent": state.get("selected_agent", {}),
+                    "interrupt_message": interrupt_message,
+                    "confirmation": False
+                }
+                outputs.append(ToolMessage(
+                    content=INTERRUPT_CANCEL_MESSAGE,
+                    name=tool_call["name"],
+                    tool_call_id=tool_call["id"],
+                    additional_kwargs=cancel_kwargs
+                ))
+                outputs.extend(self._cancel_remaining_tool_calls(tool_calls[idx + 1:], request_id, state, INTERRUPT_CANCEL_MESSAGE))
+                return {"messages": outputs}
+            if interrupt_message:
+                interrupt_messages[tool_call["id"]] = interrupt_message
+
+        # Phase 2: Execute tools (all interrupts were approved if we reach here).
+        for idx, tool_call in enumerate(tool_calls):
             additional_kwargs = {
                 "request_id": request_id,
                 "selected_agent": state.get("selected_agent", {})
             }
 
+            interrupt_message = interrupt_messages.get(tool_call["id"])
             if interrupt_message:
                 additional_kwargs["interrupt_message"] = interrupt_message
                 additional_kwargs["confirmation"] = True
-
-            if not should_continue:
-                additional_kwargs["confirmation"] = False
-                return {
-                    "messages": [ToolMessage(
-                        content=INTERRUPT_CANCEL_MESSAGE,
-                        name=tool_call["name"],
-                        tool_call_id=tool_call["id"],
-                        additional_kwargs=additional_kwargs
-                    )]
-                }
             
             try:
                 logging.debug("calling tool")
@@ -236,28 +258,41 @@ You are a highly specialized Assistant. Your primary goal is to provide accurate
                         additional_kwargs=additional_kwargs
                     )
                 )
-            except ToolException as e:
-                return {
-                    "messages": [ToolMessage(
-                        content=str(e),
-                        name=tool_call["name"],
-                        tool_call_id=tool_call["id"],
-                        additional_kwargs=additional_kwargs
-                    )]
-                }
             except Exception as e:
                 logging.error(f"unexpected error during tool call: {e}")
-                return {
-                    "messages": [ToolMessage(
-                        content=f"unexpected error during tool call: {e}",
-                        name=tool_call["name"],
-                        tool_call_id=tool_call["id"],
-                        additional_kwargs=additional_kwargs
-                    )]
-                }
+                outputs.append(ToolMessage(
+                    content=f"unexpected error during tool call: {e}",
+                    name=tool_call["name"],
+                    tool_call_id=tool_call["id"],
+                    additional_kwargs=additional_kwargs
+                ))
+                outputs.extend(self._cancel_remaining_tool_calls(tool_calls[idx + 1:], request_id, state, INTERRUPT_PREVIOUS_TOOL_FAILED_MESSAGE))
+                return {"messages": outputs}
 
         return {"messages": outputs}
     
+    def _cancel_remaining_tool_calls(self, remaining_tool_calls: list[dict], request_id: str, state: AgentState, message: str) -> list[ToolMessage]:
+        """Creates cancel ToolMessages for tool calls that will not be executed.
+
+        When a tool call is cancelled or fails, LangGraph still expects a
+        ToolMessage for every tool_call_id in the AIMessage.  This helper
+        produces the missing messages for any tool calls that come after the
+        one that stopped execution.
+        """
+        messages = []
+        for tc in remaining_tool_calls:
+            messages.append(ToolMessage(
+                content=message,
+                name=tc["name"],
+                tool_call_id=tc["id"],
+                additional_kwargs={
+                    "request_id": request_id,
+                    "selected_agent": state.get("selected_agent", {}),
+                    "confirmation": False
+                }
+            ))
+        return messages
+
     def should_summarize_conversation(self, state: AgentState):
         """
         Determines the next step in the agent's workflow.
@@ -429,7 +464,8 @@ def process_tool_result(tool_result: str | list, state: AgentState) -> tuple[str
                 f"<mcp-doclink>{link}</mcp-doclink>")
 
         # Return the value for the LLM, or the full object if 'llm' key is not present
-        return convert_to_string_if_needed(json_result.get("llm", json_result)), mcp_response
+        llm_result = json_result.get("llm", json_result) if isinstance(json_result, dict) else json_result
+        return convert_to_string_if_needed(llm_result), mcp_response
     except (json.JSONDecodeError, TypeError):
         # If it's not a valid JSON, return the raw string result
         return tool_result, mcp_response

--- a/tests/unit/services/agent/test_base_agent.py
+++ b/tests/unit/services/agent/test_base_agent.py
@@ -187,6 +187,129 @@ async def test_tool_node_human_verification_approved(mock_llm, mock_tools, mock_
     assert result["messages"][0].content == "fake k8s resource patched"
     assert result["messages"][0].additional_kwargs["confirmation"] is True
 
+@pytest.mark.asyncio
+@patch("langgraph.types.interrupt", new=MagicMock(return_value="yes"))
+async def test_tool_node_multiple_interrupts_executes_each_tool_once(mock_llm, mock_tools, mock_checkpointer, mock_config, agent_config_with_validation):
+    """Verify that when multiple tool calls require human validation, each tool is executed exactly once."""
+    
+    plan_tool = MockTool("patchKubernetesResourcePlan", "plan for patching")
+    builder = BaseAgentBuilder(
+        llm=mock_llm,
+        tools=mock_tools + [plan_tool],
+        system_prompt="system_prompt",
+        checkpointer=mock_checkpointer,
+        agent_config=agent_config_with_validation
+    )
+    tool_calls = [
+        {
+            "id": "call_1",
+            "name": "patchKubernetesResource",
+            "args": {"namespace": "ns1", "name": "res1", "kind": "Deployment", "cluster": "local", "patch": "[]"}
+        },
+        {
+            "id": "call_2",
+            "name": "patchKubernetesResource",
+            "args": {"namespace": "ns2", "name": "res2", "kind": "Deployment", "cluster": "local", "patch": "[]"}
+        }
+    ]
+    state = {"messages": [FakeMessage(tool_calls=tool_calls)]}
+
+    result = await builder.tool_node(state, mock_config)
+
+    # Both tool calls should have been executed
+    assert len(result["messages"]) == 2
+    assert result["messages"][0].tool_call_id == "call_1"
+    assert result["messages"][1].tool_call_id == "call_2"
+    assert result["messages"][0].content == "fake k8s resource patched"
+    assert result["messages"][1].content == "fake k8s resource patched"
+    # Both should be marked as confirmed
+    assert result["messages"][0].additional_kwargs["confirmation"] is True
+    assert result["messages"][1].additional_kwargs["confirmation"] is True
+    # The underlying tool should have been invoked exactly once per call
+    patch_tool = builder.tools_by_name["patchKubernetesResource"]
+    assert patch_tool.ainvoke.call_count == 2
+
+@pytest.mark.asyncio
+@patch("langgraph.types.interrupt", new=MagicMock(return_value="no"))
+async def test_tool_node_multiple_interrupts_cancel_stops_all(mock_llm, mock_tools, mock_checkpointer, mock_config, agent_config_with_validation):
+    """Verify that cancelling an interrupt prevents execution of all tool calls."""
+    plan_tool = MockTool("patchKubernetesResourcePlan", "plan for patching")
+    builder = BaseAgentBuilder(
+        llm=mock_llm,
+        tools=mock_tools + [plan_tool],
+        system_prompt="system_prompt",
+        checkpointer=mock_checkpointer,
+        agent_config=agent_config_with_validation
+    )
+    tool_calls = [
+        {
+            "id": "call_1",
+            "name": "patchKubernetesResource",
+            "args": {"namespace": "ns1", "name": "res1", "kind": "Deployment", "cluster": "local", "patch": "[]"}
+        },
+        {
+            "id": "call_2",
+            "name": "patchKubernetesResource",
+            "args": {"namespace": "ns2", "name": "res2", "kind": "Deployment", "cluster": "local", "patch": "[]"}
+        }
+    ]
+    state = {"messages": [FakeMessage(tool_calls=tool_calls)]}
+
+    result = await builder.tool_node(state, mock_config)
+
+    # Should return cancel messages for all tool calls
+    assert len(result["messages"]) == 2
+    assert result["messages"][0].content == INTERRUPT_CANCEL_MESSAGE
+    assert result["messages"][0].tool_call_id == "call_1"
+    assert result["messages"][0].additional_kwargs["confirmation"] is False
+    assert result["messages"][1].tool_call_id == "call_2"
+    assert result["messages"][1].additional_kwargs["confirmation"] is False
+    # No tool should have been invoked
+    patch_tool = builder.tools_by_name["patchKubernetesResource"]
+    assert patch_tool.ainvoke.call_count == 0
+
+@pytest.mark.asyncio
+async def test_tool_node_second_interrupt_cancelled_also_cancels_first(mock_llm, mock_tools, mock_checkpointer, mock_config, agent_config_with_validation):
+    """Verify that when the second interrupt is cancelled, the first (approved) tool is also cancelled."""
+    plan_tool = MockTool("patchKubernetesResourcePlan", "plan for patching")
+    # First call returns "yes", second returns "no"
+    interrupt_responses = iter(["yes", "no"])
+    builder = BaseAgentBuilder(
+        llm=mock_llm,
+        tools=mock_tools + [plan_tool],
+        system_prompt="system_prompt",
+        checkpointer=mock_checkpointer,
+        agent_config=agent_config_with_validation
+    )
+    tool_calls = [
+        {
+            "id": "call_1",
+            "name": "patchKubernetesResource",
+            "args": {"namespace": "ns1", "name": "res1", "kind": "Deployment", "cluster": "local", "patch": "[]"}
+        },
+        {
+            "id": "call_2",
+            "name": "patchKubernetesResource",
+            "args": {"namespace": "ns2", "name": "res2", "kind": "Deployment", "cluster": "local", "patch": "[]"}
+        }
+    ]
+    state = {"messages": [FakeMessage(tool_calls=tool_calls)]}
+
+    with patch("langgraph.types.interrupt", side_effect=lambda msg: next(interrupt_responses)):
+        result = await builder.tool_node(state, mock_config)
+
+    # Both tool calls should be cancelled
+    assert len(result["messages"]) == 2
+    assert result["messages"][0].tool_call_id == "call_1"
+    assert result["messages"][0].content == INTERRUPT_CANCEL_MESSAGE
+    assert result["messages"][0].additional_kwargs["confirmation"] is False
+    assert result["messages"][1].tool_call_id == "call_2"
+    assert result["messages"][1].content == INTERRUPT_CANCEL_MESSAGE
+    assert result["messages"][1].additional_kwargs["confirmation"] is False
+    # No tool should have been invoked
+    patch_tool = builder.tools_by_name["patchKubernetesResource"]
+    assert patch_tool.ainvoke.call_count == 0
+
 
 # ============================================================================
 # Tool Execution Tests
@@ -245,7 +368,7 @@ async def test_tool_node_handles_tool_exception(mock_llm, mock_checkpointer, moc
 
     result = await builder.tool_node(state, mock_config)
 
-    assert result["messages"][0].content == "Tool error occurred"
+    assert "Tool error occurred" in result["messages"][0].content
     assert result["messages"][0].tool_call_id == "error_123"
 
 @pytest.mark.asyncio
@@ -272,6 +395,38 @@ async def test_tool_node_handles_unexpected_exception(mock_llm, mock_checkpointe
 
     assert "unexpected error during tool call" in result["messages"][0].content
     assert "Unexpected error" in result["messages"][0].content
+
+@pytest.mark.asyncio
+async def test_tool_node_exception_cancels_remaining_tools(mock_llm, mock_checkpointer, mock_config, agent_config_without_validation):
+    """Verify that when a tool raises an exception, remaining tool calls get cancel messages."""
+    error_tool = MockTool("errorTool", "success")
+    error_tool.ainvoke = AsyncMock(side_effect=ToolException("Tool error occurred"))
+    ok_tool = MockTool("okTool", "ok result")
+
+    builder = BaseAgentBuilder(
+        llm=mock_llm,
+        tools=[error_tool, ok_tool],
+        system_prompt="system_prompt",
+        checkpointer=mock_checkpointer,
+        agent_config=agent_config_without_validation
+    )
+    tool_calls = [
+        {"id": "call_err", "name": "errorTool", "args": {}},
+        {"id": "call_ok", "name": "okTool", "args": {}}
+    ]
+    state = {"messages": [FakeMessage(tool_calls=tool_calls)]}
+
+    result = await builder.tool_node(state, mock_config)
+
+    assert len(result["messages"]) == 2
+    # First message is the error
+    assert result["messages"][0].tool_call_id == "call_err"
+    assert "Tool error occurred" in result["messages"][0].content
+    # Second message is a cancel for the remaining tool
+    assert result["messages"][1].tool_call_id == "call_ok"
+    assert result["messages"][1].additional_kwargs["confirmation"] is False
+    # The second tool should never have been invoked
+    assert ok_tool.ainvoke.call_count == 0
 
 @pytest.mark.asyncio
 async def test_tool_node_handles_multiple_tool_calls(mock_llm, mock_tools, mock_checkpointer, mock_config, agent_config_without_validation):


### PR DESCRIPTION
Fixes https://github.com/rancher/rancher-ai-agent/issues/109

## Problem
When the LLM produced multiple tool calls requiring human validation, LangGraph's node replay after each interrupt() caused previously executed tools to run again (e.g., failing with "resource already exists"). Additionally, cancels/exceptions only returned one ToolMessage instead of one per tool_call_id, breaking state.

## Solution
Split tool_node into two phases:

Resolve all interrupts first — no tools execute during this phase. If any is cancelled, all tool calls (including previously approved) get cancel messages immediately.
Execute tools — only reached when all interrupts are approved. On exception, remaining tools get cancel messages.
