### PR TITLE
Make sure we always return a valid json

### DIFF
--- a/app/routers/websocket.py
+++ b/app/routers/websocket.py
@@ -77,7 +77,7 @@ async def websocket_endpoint(websocket: WebSocket, thread_id: str = None, llm: B
         agent, agents_metadata =  await create_agent(llm=llm, websocket=websocket) 
     except NoAgentAvailableError as e:
         logging.error(f"Error creating agent: {e}")
-        await websocket.send_text(f'<chat-error>{{"message": "{str(e)}"}}</chat-error>')
+        await websocket.send_text(f'<chat-error>{json.dumps({"message": str(e)})}</chat-error>')
         await websocket.close()
         return
 
@@ -116,7 +116,7 @@ async def websocket_endpoint(websocket: WebSocket, thread_id: str = None, llm: B
         except Exception as e:
             logging.error(f"An error occurred: {e}", exc_info=True)
             if websocket.client_state == WebSocketState.CONNECTED:
-                await websocket.send_text(f'<error>{{"message": "{str(e)}"}}</error>')
+                await websocket.send_text(f'<error>{json.dumps({"message": str(e)})}</error>')
             else:
                 break
         finally:

--- a/app/services/agent/base.py
+++ b/app/services/agent/base.py
@@ -338,7 +338,11 @@ You are a highly specialized Assistant. Your primary goal is to provide accurate
                     if isinstance(plan_response[0], dict) and "text" in plan_response[0]:
                         plan_response = plan_response[0]["text"]
                 
-                return f'<confirmation-response>{plan_response}</confirmation-response>'
+                try:
+                    safe_response = json.dumps(json.loads(plan_response))
+                except (json.JSONDecodeError, TypeError):
+                    safe_response = json.dumps(plan_response)
+                return f'<confirmation-response>{safe_response}</confirmation-response>'
 
         return ""
 
@@ -370,37 +374,6 @@ You are a highly specialized Assistant. Your primary goal is to provide accurate
 def build_agent_metadata(agent_name: str, selection_mode: str, extra_metadata : str = "") -> str:
     """Builds a structured agent metadata string for custom events."""
     return f'<agent-metadata>{{"agentName": "{agent_name}", "selectionMode": "{selection_mode}"{extra_metadata}}}</agent-metadata>'
-
-
-def create_confirmation_response(payload: str, type: str, name: str, kind: str, cluster: str, namespace: str):
-    """
-    Creates a structured confirmation response for the UI.
-
-    This function formats a JSON payload that the UI can use to prompt the user
-    for confirmation before executing a sensitive operation.
-
-    Args:
-        payload: The data for the operation (e.g., a patch or a resource definition).
-        type: The type of operation (e.g., "patch").
-        name: The name of the resource.
-        kind: The kind of the resource (e.g., "Deployment").
-        cluster: The target cluster.
-        namespace: The target namespace.
-    """
-    payload_data = {
-        "payload": payload,
-        "type": type,
-        "resource": {
-            "name": name,
-            "kind": kind,
-            "cluster": cluster,
-            "namespace": namespace
-        }
-    }
-
-    json_payload = json.dumps(payload_data)
-
-    return f'<confirmation-response>{json_payload}</confirmation-response>'
 
 
 def process_tool_result(tool_result: str | list, state: AgentState) -> tuple[str, str | None]:

--- a/tests/unit/services/agent/test_base_agent.py
+++ b/tests/unit/services/agent/test_base_agent.py
@@ -7,7 +7,6 @@ import json
 
 from unittest.mock import AsyncMock, MagicMock, patch
 from app.services.agent.base import (
-    create_confirmation_response,
     process_tool_result,
     convert_to_string_if_needed,
     INTERRUPT_CANCEL_MESSAGE,
@@ -609,20 +608,6 @@ def test_should_continue_after_interrupt_continues_on_success(mock_llm, mock_too
 # ============================================================================
 # Helper Function Tests
 # ============================================================================
-
-def test_create_confirmation_response_formats_correctly():
-    """Verify confirmation response JSON structure."""
-    result = create_confirmation_response(
-        payload='{"key": "value"}',
-        type="update",
-        name="test-resource",
-        kind="Deployment",
-        cluster="local",
-        namespace="default"
-    )
-    
-    expected = '<confirmation-response>{"payload": "{\\"key\\": \\"value\\"}", "type": "update", "resource": {"name": "test-resource", "kind": "Deployment", "cluster": "local", "namespace": "default"}}</confirmation-response>'
-    assert result == expected
 
 @pytest.mark.asyncio
 async def test_should_interrupt_returns_message_for_update_tools(mock_llm, mock_checkpointer):


### PR DESCRIPTION
Make sure we always return a valid json for the human validation payload and errors
Remove unused create_confirmation_response method