### PR TITLE
Limit max number of consecutive tools to 5

### DIFF
--- a/app/services/agent/base.py
+++ b/app/services/agent/base.py
@@ -18,6 +18,7 @@ from .state import AgentState
 
 INTERRUPT_CANCEL_MESSAGE = "tool execution cancelled by the user"
 INTERRUPT_PREVIOUS_TOOL_FAILED_MESSAGE = "tool execution cancelled because previous tool call failed"
+MAX_CONSECUTIVE_TOOL_CALLS = 5
 
 class BaseAgentBuilder:
     """Base class for agent builders with shared logic."""
@@ -103,6 +104,26 @@ class BaseAgentBuilder:
             }
         }
 
+    def _count_consecutive_tool_rounds(self, state: AgentState) -> int:
+        """Count the number of consecutive tool call rounds since the last HumanMessage.
+        
+        A tool call round is counted for each AIMessage that contains tool_calls.
+        Counting stops when a HumanMessage is encountered.
+        
+        Args:
+            state: The current state of the agent.
+
+        Returns:
+            The number of consecutive tool call rounds.
+        """
+        count = 0
+        for msg in reversed(state["messages"]):
+            if isinstance(msg, HumanMessage):
+                break
+            if hasattr(msg, "tool_calls") and msg.tool_calls:
+                count += 1
+        return count
+
     def _invoke_llm_with_retry(self, messages: list, config: RunnableConfig):
         """
         Invokes the LLM, with a single retry for a tool call parsing error.
@@ -165,7 +186,24 @@ You are a highly specialized Assistant. Your primary goal is to provide accurate
         
         messages.extend(base_messages)
 
-        response = self._invoke_llm_with_retry(messages, config)
+        # Check if consecutive tool call limit has been reached
+        consecutive_rounds = self._count_consecutive_tool_rounds(state)
+        if consecutive_rounds >= MAX_CONSECUTIVE_TOOL_CALLS:
+            logging.warning(
+                f"Reached maximum consecutive tool calls ({MAX_CONSECUTIVE_TOOL_CALLS}). "
+                "Forcing LLM to respond without tools."
+            )
+            forced_answer_messages = messages + [HumanMessage(
+                content=(
+                    "You have reached the maximum number of consecutive tool calls. "
+                    "You MUST now provide a final answer based on the information gathered so far. "
+                    "Do NOT request any more tool calls. "
+                    "If you need more information, ask the user to provide it."
+                )
+            )]
+            response = self.llm.invoke(forced_answer_messages, config)
+        else:
+            response = self._invoke_llm_with_retry(messages, config)
 
         response.additional_kwargs["request_id"] = config["configurable"]["request_id"]
         response.additional_kwargs["selected_agent"] = state.get("selected_agent", {})

--- a/tests/unit/services/agent/test_base_agent.py
+++ b/tests/unit/services/agent/test_base_agent.py
@@ -570,6 +570,130 @@ def test_call_model_node_uses_sliding_window_with_summary(mock_llm, mock_tools, 
     assert len(call_args) == 5
 
 # ============================================================================
+# Consecutive Tool Call Limit Tests
+# ============================================================================
+
+def test_count_consecutive_tool_rounds_no_tool_calls(mock_llm, mock_tools, mock_checkpointer):
+    """Verify that counting returns 0 when there are no tool call rounds."""
+    builder = BaseAgentBuilder(
+        llm=mock_llm,
+        tools=mock_tools,
+        system_prompt="system_prompt",
+        checkpointer=mock_checkpointer,
+        agent_config=MagicMock()
+    )
+    state = {"messages": [HumanMessage(content="Hello")]}
+    assert builder._count_consecutive_tool_rounds(state) == 0
+
+def test_count_consecutive_tool_rounds_counts_correctly(mock_llm, mock_tools, mock_checkpointer):
+    """Verify that consecutive tool call rounds are counted correctly."""
+    builder = BaseAgentBuilder(
+        llm=mock_llm,
+        tools=mock_tools,
+        system_prompt="system_prompt",
+        checkpointer=mock_checkpointer,
+        agent_config=MagicMock()
+    )
+    state = {
+        "messages": [
+            HumanMessage(content="Hello"),
+            AIMessage(content="", tool_calls=[{"id": "1", "name": "tool1", "args": {}}]),
+            ToolMessage(content="result1", tool_call_id="1"),
+            AIMessage(content="", tool_calls=[{"id": "2", "name": "tool2", "args": {}}]),
+            ToolMessage(content="result2", tool_call_id="2"),
+            AIMessage(content="", tool_calls=[{"id": "3", "name": "tool3", "args": {}}]),
+            ToolMessage(content="result3", tool_call_id="3"),
+        ]
+    }
+    assert builder._count_consecutive_tool_rounds(state) == 3
+
+def test_count_consecutive_tool_rounds_resets_on_human_message(mock_llm, mock_tools, mock_checkpointer):
+    """Verify that the count resets when a HumanMessage is encountered."""
+    builder = BaseAgentBuilder(
+        llm=mock_llm,
+        tools=mock_tools,
+        system_prompt="system_prompt",
+        checkpointer=mock_checkpointer,
+        agent_config=MagicMock()
+    )
+    state = {
+        "messages": [
+            HumanMessage(content="First question"),
+            AIMessage(content="", tool_calls=[{"id": "1", "name": "tool1", "args": {}}]),
+            ToolMessage(content="result1", tool_call_id="1"),
+            AIMessage(content="", tool_calls=[{"id": "2", "name": "tool2", "args": {}}]),
+            ToolMessage(content="result2", tool_call_id="2"),
+            HumanMessage(content="Second question"),
+            AIMessage(content="", tool_calls=[{"id": "3", "name": "tool3", "args": {}}]),
+            ToolMessage(content="result3", tool_call_id="3"),
+        ]
+    }
+    assert builder._count_consecutive_tool_rounds(state) == 1
+
+def test_call_model_node_forces_answer_at_tool_call_limit(mock_llm, mock_tools, mock_checkpointer, mock_config):
+    """Verify that the LLM is called without tools when the consecutive tool call limit is reached."""
+    from app.services.agent.base import MAX_CONSECUTIVE_TOOL_CALLS
+
+    # Create a separate mock for llm (no tools) vs llm_with_tools
+    llm_no_tools = MagicMock()
+    llm_no_tools.invoke = MagicMock(return_value=AIMessage(content="final answer based on gathered info"))
+    llm_no_tools.bind_tools = MagicMock(return_value=MagicMock())
+
+    builder = BaseAgentBuilder(
+        llm=llm_no_tools,
+        tools=mock_tools,
+        system_prompt="You are a helpful assistant",
+        checkpointer=mock_checkpointer,
+        agent_config=MagicMock()
+    )
+
+    # Build messages with MAX_CONSECUTIVE_TOOL_CALLS tool call rounds
+    messages = [HumanMessage(content="Analyze the app")]
+    for i in range(MAX_CONSECUTIVE_TOOL_CALLS):
+        messages.append(AIMessage(content="", tool_calls=[{"id": str(i), "name": "getKubernetesResource", "args": {}}]))
+        messages.append(ToolMessage(content=f"result{i}", tool_call_id=str(i)))
+
+    state = {"messages": messages}
+    result = builder.call_model_node(state, mock_config)
+
+    # The LLM (without tools) should have been called, not llm_with_tools
+    llm_no_tools.invoke.assert_called_once()
+    call_args = llm_no_tools.invoke.call_args[0][0]
+    # The last message should be the system message forcing a final answer
+    assert "maximum number of consecutive tool calls" in call_args[-1].content
+    assert result["messages"][0].content == "final answer based on gathered info"
+
+def test_call_model_node_allows_tools_below_limit(mock_llm, mock_tools, mock_checkpointer, mock_config):
+    """Verify that tools are still available when under the consecutive tool call limit."""
+    from app.services.agent.base import MAX_CONSECUTIVE_TOOL_CALLS
+
+    builder = BaseAgentBuilder(
+        llm=mock_llm,
+        tools=mock_tools,
+        system_prompt="You are a helpful assistant",
+        checkpointer=mock_checkpointer,
+        agent_config=MagicMock()
+    )
+
+    # Build messages with fewer tool call rounds than the limit
+    messages = [HumanMessage(content="Analyze the app")]
+    for i in range(MAX_CONSECUTIVE_TOOL_CALLS - 1):
+        messages.append(AIMessage(content="", tool_calls=[{"id": str(i), "name": "getKubernetesResource", "args": {}}]))
+        messages.append(ToolMessage(content=f"result{i}", tool_call_id=str(i)))
+
+    state = {"messages": messages}
+    builder.call_model_node(state, mock_config)
+
+    # llm_with_tools (which is mock_llm after bind_tools) should have been called
+    mock_llm.invoke.assert_called_once()
+    call_args = mock_llm.invoke.call_args[0][0]
+    # No forced-answer system message should be present
+    assert not any(
+        hasattr(m, "content") and "maximum number of consecutive tool calls" in str(m.content)
+        for m in call_args
+    )
+
+# ============================================================================
 # Conversation Summarization Tests
 # ============================================================================
 


### PR DESCRIPTION
## Issue https://github.com/rancher/rancher-ai-agent/issues/157

LLM can get stuck in a loop and crash. This PR limits the maximum number of consecutive tools to 5