### PR TITLE
fix(chart): add system-default-registry support to image references

### DIFF
--- a/chart/agent/templates/_helpers.tpl
+++ b/chart/agent/templates/_helpers.tpl
@@ -1,0 +1,5 @@
+{{- define "system_default_registry" -}}
+{{- if .Values.global.cattle.systemDefaultRegistry -}}
+{{- printf "%s/" .Values.global.cattle.systemDefaultRegistry -}}
+{{- end -}}
+{{- end -}}

--- a/chart/agent/templates/ai-agent-deployment.yaml
+++ b/chart/agent/templates/ai-agent-deployment.yaml
@@ -34,7 +34,7 @@ spec:
       {{- end }}
       {{- end }}
       containers:
-      - image: "{{ .Values.aiAgent.image.repository }}:{{ .Values.aiAgent.image.tag }}"
+      - image: "{{ template "system_default_registry" . }}{{ .Values.aiAgent.image.repository }}:{{ .Values.aiAgent.image.tag }}"
         imagePullPolicy: "{{ .Values.aiAgent.image.pullPolicy }}"
         name: agent
         env:

--- a/chart/agent/templates/mcp-deployment.yaml
+++ b/chart/agent/templates/mcp-deployment.yaml
@@ -23,7 +23,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:
-      - image: "{{ .Values.mcp.image.repository }}:{{ .Values.mcp.image.tag }}"
+      - image: "{{ template "system_default_registry" . }}{{ .Values.mcp.image.repository }}:{{ .Values.mcp.image.tag }}"
         imagePullPolicy: "{{ .Values.mcp.image.pullPolicy }}"
         name: mcp-server
         ports:

--- a/chart/agent/values.yaml
+++ b/chart/agent/values.yaml
@@ -1,3 +1,7 @@
+global:
+  cattle:
+    systemDefaultRegistry: ""
+
 aiAgent:
   image:
     repository: rancher/rancher-ai-agent


### PR DESCRIPTION
## Summary

- Add `global.cattle.systemDefaultRegistry: ""` to `values.yaml` to expose the Rancher setting
- Add `templates/_helpers.tpl` with `system_default_registry` define that prepends the registry when set
- Update `ai-agent-deployment.yaml` and `mcp-deployment.yaml` to prefix image references with the helper

## Why

Commit e1ae252 stripped the staging registry prefix from both image repositories in `values.yaml`
(`stgregistry.suse.com/rancher/rancher-ai-agent` → `rancher/rancher-ai-agent`), which is the correct
long-term state. However, without the `system_default_registry` helper in place, Kubernetes resolves
the bare `rancher/...` reference against Docker Hub, where the RC images do not exist — causing
`ErrImagePullBackOff`.

`system-default-registry` is a Rancher platform setting (`global.cattle.systemDefaultRegistry`) that
is automatically injected into chart values by Rancher's catalog machinery at deploy time. When set,
it is prepended to all image references, allowing air-gapped and Prime customers to redirect pulls to
a private registry without touching chart values. The standard pattern across Rancher charts is a
`_helpers.tpl` define that conditionally prepends the registry with a trailing slash:

```yaml
{{- define "system_default_registry" -}}
{{- if .Values.global.cattle.systemDefaultRegistry -}}
{{- printf "%s/" .Values.global.cattle.systemDefaultRegistry -}}
{{- end -}}
{{- end -}}
```

With this in place, deploying through Rancher catalog with `system-default-registry` set to
`stgregistry.suse.com` produces the correct image reference:
`stgregistry.suse.com/rancher/rancher-ai-agent:v1.0.0-rc.5`.
When unset, the reference resolves to `rancher/rancher-ai-agent:v1.0.0-rc.5` as intended for
public distribution.