### PR TITLE
feat(security): create rancher-ai-agent and rancher-ai-mcp security context

### DIFF
--- a/chart/agent/templates/ai-agent-deployment.yaml
+++ b/chart/agent/templates/ai-agent-deployment.yaml
@@ -19,9 +19,26 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+        # If seLinux.enabled is set to true in values.yaml, the container will run as type rancher_aiagent_container_t.
+        # Note: https://github.com/rancher/rancher-selinux policy should be installed.
+        {{- if .Values.seLinux.enabled }}
+        seLinuxOptions:
+          type: rancher_aiagent_container_t
+        {{- end }}
       serviceAccountName: agent-sa
-      {{- if or (not .Values.insecureSkipTls) .Values.rag.pvc }}
       volumes:
+      - name: tmp-dir
+        emptyDir: {}
+      - name: cert-dir
+        emptyDir: {}
+      {{- if or (not .Values.insecureSkipTls) .Values.rag.pvc }}
       {{- if not .Values.insecureSkipTls }}
       - name: mcp-ca-volume
         secret:
@@ -37,6 +54,13 @@ spec:
       - image: "{{ template "system_default_registry" . }}{{ .Values.aiAgent.image.repository }}:{{ .Values.aiAgent.image.tag }}"
         imagePullPolicy: "{{ .Values.aiAgent.image.pullPolicy }}"
         name: agent
+        securityContext:
+          allowPrivilegeEscalation: false
+          privileged: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+              - ALL
         env:
           - name: OPENAI_API_KEY
             valueFrom:
@@ -151,15 +175,19 @@ spec:
             path: /v1/api/readiness
             port: 8000
           {{ toYaml .Values.probes.readiness | nindent 10 }}
-        {{- if or (not .Values.insecureSkipTls) .Values.rag.pvc }}
         volumeMounts:
+        - name: tmp-dir
+          mountPath: /tmp
+        - name: cert-dir
+          mountPath: /cert
+        {{- if or (not .Values.insecureSkipTls) .Values.rag.pvc }}
         {{- if not .Values.insecureSkipTls }}
-          - name: mcp-ca-volume
-            mountPath: /etc/tls
-            readOnly: true
+        - name: mcp-ca-volume
+          mountPath: /etc/tls
+          readOnly: true
         {{- end }}
         {{- if .Values.rag.pvc }}
-          - name: rag-storage
-            mountPath: /app/rag
+        - name: rag-storage
+          mountPath: /app/rag
         {{- end }}
         {{- end }}

--- a/chart/agent/templates/mcp-deployment.yaml
+++ b/chart/agent/templates/mcp-deployment.yaml
@@ -22,25 +22,50 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+        # If seLinux.enabled is set to true in values.yaml, the container will run as type rancher_aimcp_container_t.
+        # Note: https://github.com/rancher/rancher-selinux policy should be installed.
+        {{- if .Values.seLinux.enabled }}
+        seLinuxOptions:
+          type: rancher_aimcp_container_t
+        {{- end }}
+      volumes:
+        - name: tmp-dir
+          emptyDir: {}
       containers:
       - image: "{{ template "system_default_registry" . }}{{ .Values.mcp.image.repository }}:{{ .Values.mcp.image.tag }}"
         imagePullPolicy: "{{ .Values.mcp.image.pullPolicy }}"
         name: mcp-server
+        securityContext:
+          allowPrivilegeEscalation: false
+          privileged: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+              - ALL
         ports:
-         - containerPort: 9092
+          - containerPort: 9092
         command: ["/usr/local/bin/mcp"]
         args:
           - "serve"
           - "--port"
           - "9092"
-        {{- if .Values.insecureSkipTls }}
+          {{- if .Values.insecureSkipTls }}
           - "--insecure"
-        {{- end }}
-        {{- if .Values.mcp.readOnly }}
+          {{- end }}
+          {{- if .Values.mcp.readOnly }}
           - "--read-only"
-        {{- end }}
-        {{- if .Values.log.level }}
+          {{- end }}
+          {{- if .Values.log.level }}
           - "--log-level"
           - "{{ .Values.log.level }}"
-        {{- end }}
-
+          {{- end }}
+        volumeMounts:
+          - name: tmp-dir
+            mountPath: /tmp

--- a/chart/agent/values.yaml
+++ b/chart/agent/values.yaml
@@ -53,6 +53,8 @@ probes:
     timeoutSeconds: 5
     failureThreshold: 2
 insecureSkipTls: false
+seLinux:
+  enabled: false
 llmMock:
   enabled: false
   url: ""


### PR DESCRIPTION
## Description

This PR significantly hardens the security posture of the Rancher AI components: the **AI Agent** and **MCP Server**. By implementing a "least privilege" model and introducing native SELinux support (beta).

The primary goal is to shift from a standard privileged/root container model to a hardened, read-only configuration that aligns with the **Kubernetes Restricted Pod Security Standard**.


## Key Changes

### 1. Hardened Pod Security Contexts
The `ai-agent` and `mcp-server` deployments now enforce:
* **Non-Root Execution:** UID/GID 1000 is enforced.
* **Privilege Escalation:** `allowPrivilegeEscalation: false` to prevent gaining root via setuid binaries.
* **Capabilities:** All Linux capabilities are dropped (`ALL`).
* **Seccomp:** Enabled the `RuntimeDefault` profile.
* **Immutable Filesystem:** `readOnlyRootFilesystem: true` to prevent persistent malware injection.

### 2. Filesystem Adaptations
To support the read-only root, `emptyDir` volumes are now mounted for volatile paths:
* **MCP Server:** Added `/tmp`.
* **AI Agent:** Added `/tmp` and `/cert` (for dynamic certificate handling).

### 3. Dedicated SELinux type/policy 
Introduces a configuration hook in `values.yaml` to enable specific SELinux types: `rancher_aiagent_container_t` and `rancher_aimcp_container_t`.

* **Why a dedicated type?** By default, containers typically run under the generic `container_t` label. By assigning a **dedicated type**, we enforce strict **Type Enforcement (TE)**. This isolates the AI components into their own security domains, effectively preventing **lateral movement** to other containers or host services in the event of a process compromise.
* **Policy Requirement:** To function, the `[rancher-selinux](https://github.com/rancher/rancher-selinux)` policy package must be installed on the host OS, as it ships the definitions and authorizations for these two new types. If the policy is not present, the system will gracefully fallback to the standard `container_t`.


## How to Test
1. **Verify SELinux Labeling:** 
   - Install rancher/rancher-selinux policy and verify the module and types are loaded (in progress: https://github.com/rancher/rancher-selinux/pull/133)
   - Install rancher-ai chart using `seLinux.enabled: true`. 
   - Run `ps -eZ | grep ai-agent` to confirm it is running under the specific `rancher_aiagent_container_t` context.
3.  **Verify Read-Only:** Exec into a pod and attempt to `touch /test`; it should return a "Read-only file system" error.
4.  **Verify Capabilities:** Run `capsh --print` inside the container to confirm that all capabilities have been successfully dropped.

```
[root@lima-centos10 ~]# helm install rancher-ai-agent ./chart/agent/   --namespace cattle-ai-agent-system   --create-namespace   --set seLinux.enabled=true

[root@lima-centos10 ~]# semodule -l | grep rancher
rancher
[root@lima-centos10 ~]# seinfo -t rancher_aimcp_container_t -x

Types: 1
   type rancher_aimcp_container_t, can_dump_kernel, can_receive_kernel_messages, corenet_unlabeled_type, domain, mcs_constrained_type, process_user_target, container_domain, pcmcia_typeattr_1;
[root@lima-centos10 ~]# seinfo -t rancher_aiagent_container_t -x

Types: 1
   type rancher_aiagent_container_t, can_dump_kernel, can_receive_kernel_messages, corenet_unlabeled_type, domain, mcs_constrained_type, process_user_target, container_domain, pcmcia_typeattr_1;

[root@lima-centos10 ~]# kubectl get pods -n cattle-ai-agent-system
NAME                                  READY   STATUS    RESTARTS   AGE
rancher-ai-agent-99b4bb968-r2prp      1/1     Running   0          6h14m
rancher-mcp-server-6c97b78669-j4hdg   1/1     Running   0          6h14m

[root@lima-centos10 ~]# ps -eaZ | grep rancher_
system_u:system_r:rancher_aiagent_container_t:s0:c153,c540 1398567 ? 00:00:00 pause
system_u:system_r:rancher_aimcp_container_t:s0:c476,c560 1398574 ? 00:00:00 pause
system_u:system_r:rancher_aimcp_container_t:s0:c393,c437 1398625 ? 00:00:01 mcp
system_u:system_r:rancher_aiagent_container_t:s0:c672,c1008 1398632 ? 00:01:30 python3
```

# TODO:

- Confirm that all the functionality remains intact.
- If some restrictions are too restrictive, we could propose them as a hardened version rather than a baseline. If so, we should document it in the Rancher Docs (hardening guide).