### PR TITLE
Remove AIMessage with tool calls from routing agent prompt

### DIFF
--- a/app/services/agent/parent.py
+++ b/app/services/agent/parent.py
@@ -121,7 +121,12 @@ class ParentAgentBuilder(BaseAgentBuilder):
             router_prompt += f"- {child.config.name}: {child.config.description}\n"
         router_prompt += f"\nUSER'S REQUEST: {messages[-1].content}"
         
-        user_and_ai_messages = [msg for msg in self._get_messages_from_last_summary(state) if isinstance(msg, (HumanMessage, AIMessage, SystemMessage))]
+        # Exclude tool calls
+        user_and_ai_messages = [
+            msg for msg in self._get_messages_from_last_summary(state)
+            if isinstance(msg, (HumanMessage, SystemMessage))
+            or (isinstance(msg, AIMessage) and not msg.tool_calls)
+        ]
 
         # Use LLM to select the appropriate child agent
         child_agent = self.llm.invoke([SystemMessage(content=router_prompt)] + user_and_ai_messages).text.strip()


### PR DESCRIPTION
## Issue https://github.com/rancher/rancher-ai-agent/issues/172

### Problem
When a tool has been previously executed, the conversation history contains an `AIMessage` with `tool_calls`. OpenAI’s API strictly requires that these calls be followed by corresponding `ToolMessages`. If they are missing or mismatched during the agent selection step, the request fails.

### Solution
This PR removes all `ToolMessages` and their preceding `AIMessage` (with `tool_calls`) before the agent selection call. These messages are not needed for deciding which agent to use.