### PR TITLE
Add header authentication type for MCP servers

### DIFF
--- a/app/services/agent/factory.py
+++ b/app/services/agent/factory.py
@@ -4,7 +4,7 @@ from datetime import datetime, timezone
 
 from kubernetes import client, config
 from .root import create_root_agent
-from .loader import AuthenticationType, load_agent_configs, AgentConfig, get_basic_auth_credentials
+from .loader import AuthenticationType, load_agent_configs, AgentConfig, get_basic_auth_credentials, get_header_auth_headers
 from .child import create_child_agent
 from .parent import create_parent_agent, ChildAgent
 from fastapi import  WebSocket
@@ -160,6 +160,13 @@ def create_mcp_client(agent_config: AgentConfig, websocket: WebSocket | None = N
             }
         except Exception as e:
             logging.error(f"Failed to get basic auth credentials: {str(e)}")
+
+    elif agent_config.authentication == AuthenticationType.HEADER:
+        mcp_url = agent_config.mcp_url
+        try:
+            headers = get_header_auth_headers(agent_config.authentication_secret)
+        except Exception as e:
+            logging.error(f"Failed to get header auth headers: {str(e)}")
 
     else:
         mcp_url = agent_config.mcp_url

--- a/app/services/agent/loader.py
+++ b/app/services/agent/loader.py
@@ -21,6 +21,7 @@ class AuthenticationType(str, Enum):
     NONE = "NONE"
     RANCHER = "RANCHER"
     BASIC = "BASIC"
+    HEADER = "HEADER"
 
 
 class ToolActionType(str, Enum):
@@ -274,6 +275,38 @@ def get_basic_auth_credentials(secret_name: str) -> str:
     credentials = base64.b64encode(f"{username}:{password}".encode('utf-8')).decode('utf-8')
     return credentials
 
+
+def get_header_auth_headers(secret_name: str) -> dict[str, str]:
+    """
+    Retrieve custom headers from a Kubernetes secret.
+
+    Each key in the secret is used as a header name and its decoded value
+    as the header value.
+
+    Args:
+        secret_name: Name of the Opaque secret containing header key-value pairs.
+
+    Returns:
+        dict[str, str]: Mapping of header names to their values.
+    """
+    try:
+        config.load_incluster_config()
+    except config.ConfigException:
+        config.load_kube_config()
+
+    v1 = client.CoreV1Api()
+    secret = v1.read_namespaced_secret(secret_name, NAMESPACE)
+
+    if not secret.data:
+        raise RuntimeError(
+            f"Authentication secret '{secret_name}' in namespace '{NAMESPACE}' is empty"
+        )
+
+    headers = {}
+    for key, value in secret.data.items():
+        headers[key] = base64.b64decode(value).decode('utf-8')
+
+    return headers
 
 
 def _crd_to_agent_config(crd_obj: dict) -> AgentConfig:

--- a/chart/agent/templates/crds/ai.cattle.io_aiagentconfigs.yaml
+++ b/chart/agent/templates/crds/ai.cattle.io_aiagentconfigs.yaml
@@ -60,6 +60,7 @@ spec:
                 - RANCHER
                 - NONE
                 - BASIC
+                - HEADER
                 type: string
               builtIn:
                 description: BuiltIn indicates if this is a built-in agent configuration

--- a/crd-generation/api/v1alpha1/aiagentconfig_types.go
+++ b/crd-generation/api/v1alpha1/aiagentconfig_types.go
@@ -24,7 +24,7 @@ type AIAgentConfigSpec struct {
 	MCPURL string `json:"mcpURL,omitempty"`
 
 	// AuthenticationType specifies the authentication method
-	// +kubebuilder:validation:Enum=RANCHER;NONE;BASIC
+	// +kubebuilder:validation:Enum=RANCHER;NONE;BASIC;HEADER
 	// +optional
 	AuthenticationType string `json:"authenticationType,omitempty"`
 

--- a/tests/unit/services/agent/test_factory.py
+++ b/tests/unit/services/agent/test_factory.py
@@ -548,3 +548,31 @@ async def test_create_single_agent_filters_tools_by_toolset(mock_update_status, 
     filtered_tools = mock_create_root.call_args[0][1]
     assert len(filtered_tools) == 1
     assert filtered_tools[0].name == "matching_tool"
+
+
+@patch('app.services.agent.factory.MultiServerMCPClient')
+@patch('app.services.agent.factory.get_header_auth_headers')
+def test_create_mcp_client_header_auth(mock_get_headers, mock_mcp_client):
+    """Verify create_mcp_client handles header authentication."""
+    mock_config = MagicMock()
+    mock_config.name = "TestAgent"
+    mock_config.authentication = AuthenticationType.HEADER
+    mock_config.mcp_url = "http://test:8080"
+    mock_config.authentication_secret = "my-headers-secret"
+
+    mock_get_headers.return_value = {
+        "X-Api-Key": "my-api-key",
+        "Authorization": "Bearer tok123",
+    }
+
+    mock_client_instance = MagicMock()
+    mock_mcp_client.return_value = mock_client_instance
+
+    result = create_mcp_client(mock_config)
+
+    assert result == mock_client_instance
+    call_args = mock_mcp_client.call_args[0][0]
+    assert call_args["TestAgent"]["url"] == "http://test:8080"
+    assert call_args["TestAgent"]["headers"]["X-Api-Key"] == "my-api-key"
+    assert call_args["TestAgent"]["headers"]["Authorization"] == "Bearer tok123"
+    mock_get_headers.assert_called_once_with("my-headers-secret")

--- a/tests/unit/services/agent/test_loader.py
+++ b/tests/unit/services/agent/test_loader.py
@@ -14,7 +14,7 @@ from app.services.agent.loader import (
     NAMESPACE,
 )
 
-from app.services.agent.loader import get_basic_auth_credentials, NAMESPACE
+from app.services.agent.loader import get_basic_auth_credentials, get_header_auth_headers, NAMESPACE
 
 
 # ============================================================================
@@ -332,3 +332,69 @@ def test_update_ignores_enabled_field_change():
     # enabled change must not cause any patch or create
     mock_api.patch_namespaced_custom_object.assert_not_called()
     mock_api.create_namespaced_custom_object.assert_not_called()
+
+
+# ============================================================================
+# get_header_auth_headers Tests
+# ============================================================================
+
+@patch('app.services.agent.loader.config')
+@patch('app.services.agent.loader.client')
+def test_get_header_auth_headers_success(mock_k8s_client, mock_config):
+    """Verify get_header_auth_headers successfully retrieves and decodes headers."""
+    secret_name = "my-headers-secret"
+
+    mock_v1 = MagicMock()
+    mock_k8s_client.CoreV1Api.return_value = mock_v1
+
+    mock_secret = MagicMock()
+    mock_secret.data = {
+        'X-Api-Key': base64.b64encode(b'my-api-key').decode('utf-8'),
+        'Authorization': base64.b64encode(b'Bearer tok123').decode('utf-8'),
+    }
+    mock_v1.read_namespaced_secret.return_value = mock_secret
+
+    result = get_header_auth_headers(secret_name)
+
+    assert result == {
+        'X-Api-Key': 'my-api-key',
+        'Authorization': 'Bearer tok123',
+    }
+    mock_v1.read_namespaced_secret.assert_called_once_with(secret_name, NAMESPACE)
+
+
+@patch('app.services.agent.loader.config')
+@patch('app.services.agent.loader.client')
+def test_get_header_auth_headers_empty_secret(mock_k8s_client, mock_config):
+    """Verify get_header_auth_headers raises RuntimeError for empty secret."""
+    secret_name = "empty-secret"
+
+    mock_v1 = MagicMock()
+    mock_k8s_client.CoreV1Api.return_value = mock_v1
+
+    mock_secret = MagicMock()
+    mock_secret.data = None
+    mock_v1.read_namespaced_secret.return_value = mock_secret
+
+    with pytest.raises(RuntimeError) as exc_info:
+        get_header_auth_headers(secret_name)
+
+    assert f"Authentication secret '{secret_name}'" in str(exc_info.value)
+    assert "is empty" in str(exc_info.value)
+
+
+@patch('app.services.agent.loader.config')
+@patch('app.services.agent.loader.client')
+def test_get_header_auth_headers_api_exception(mock_k8s_client, mock_config):
+    """Verify get_header_auth_headers propagates ApiException from Kubernetes."""
+    secret_name = "nonexistent-secret"
+
+    mock_v1 = MagicMock()
+    mock_k8s_client.CoreV1Api.return_value = mock_v1
+
+    mock_v1.read_namespaced_secret.side_effect = ApiException(status=404, reason="Not Found")
+
+    with pytest.raises(ApiException) as exc_info:
+        get_header_auth_headers(secret_name)
+
+    assert exc_info.value.status == 404


### PR DESCRIPTION
## Issue https://github.com/rancher/rancher-ai-agent/issues/182

Adds support for a new header authentication type in the `AIAgentConfig` CRD. When set, the agent factory loads custom HTTP headers from the `authenticationSecret` and passes them to the MCP client connection.

- Updated CRD schema + Go types to include the new `HEADER` auth type
- Factory now reads and injects headers from the secret. Each key pair will be a new header

 `authenticationSecret` is also used for Basic Auth and it will be used for OAuth2. The format expected will be different based on the auth type

The following secret:

```yaml
apiVersion: v1
kind: Secret
metadata:
  name: header-secret
data:
  X-API-Key: xxxxx
```

will add the `X-API-Key: xxxxx` header to the MCP connection