### PR TITLE
Custom CA and TLS improvements

### DIFF
--- a/app/controllers/ai_agent_config.py
+++ b/app/controllers/ai_agent_config.py
@@ -12,7 +12,7 @@ import kopf
 
 from kopf._cogs.configs.configuration import ScanningSettings, PostingSettings
 from datetime import datetime, timezone
-from ..services.agent.loader import AgentConfig
+from ..services.agent.loader import AgentConfig, CABundleRef
 from ..services.agent.factory import create_mcp_client
 
 
@@ -187,7 +187,8 @@ async def create_fn(spec, name, namespace, logger, patch, **kwargs):
         system_prompt=spec.get('systemPrompt', ''),
         mcp_url=spec.get('mcpURL', ''),
         authentication=spec.get('authenticationType', ''),
-        authentication_secret=spec.get('authenticationSecret', '')
+        authentication_secret=spec.get('authenticationSecret', ''),
+        ca_bundle_ref=CABundleRef(**spec["caBundleRef"]) if spec.get("caBundleRef") else None,
     )
     try:
         # Validate the configuration by testing MCP server connection

--- a/app/main.py
+++ b/app/main.py
@@ -58,50 +58,12 @@ _sensitive_filter = _SensitiveHeaderFilter()
 for _handler in logging.getLogger().handlers:
     _handler.addFilter(_sensitive_filter)
 logging.getLogger("uvicorn.access").addFilter(_NoisyEndpointFilter())
-
-# This will be removed once https://github.com/modelcontextprotocol/python-sdk/pull/1177 is merged
-class SimpleTruststore:
-    def get_default(self):
-        """Get the default Python truststore"""
-        return certifi.where()
-
-    def create_combined(self, company_cert_path, output_path):
-        """Create truststore with public CAs + company cert"""
-        with open(output_path, "w") as combined:
-            # Add public CAs 
-            with open(certifi.where(), "r") as public_cas:
-                combined.write(public_cas.read())
-
-            # Add MCP self-signed cert
-            with open(company_cert_path, "r") as company:
-                combined.write("\n" + company.read())
-
-        return output_path
-    
-    def use_truststore(self, truststore_path):
-        """Set the global truststore"""
-        os.environ["SSL_CERT_FILE"] = truststore_path
-
-    def set_truststore(self):
-        company_cert_path = "/etc/tls/tls.crt"
-        output_path = "/cert/combined.crt"
-
-        if os.path.exists(company_cert_path):
-            truststore_path = self.create_combined(
-                company_cert_path=company_cert_path, output_path=output_path
-            )
-            self.use_truststore(truststore_path=truststore_path)
-        else:
-            logging.warning(f"Company cert not found at {company_cert_path}, skipping truststore setup.")
-
         
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     try:
         LOG_LEVEL = os.environ.get('LOG_LEVEL', 'INFO').upper()
         logging.getLogger().setLevel(LOG_LEVEL)
-        if os.environ.get('INSECURE_SKIP_TLS', 'false').lower() != "true":
-            SimpleTruststore().set_truststore()
 
         configs = ensure_default_ai_agent_config_crds()
         logging.info(f"Startup: {len(configs)} AIAgentConfig CRDs in the cluster.")

--- a/app/services/agent/factory.py
+++ b/app/services/agent/factory.py
@@ -1,11 +1,12 @@
 import os
+import ssl
 import logging
 from datetime import datetime, timezone
 
 import httpx
 from kubernetes import client, config
 from .root import create_root_agent
-from .loader import AuthenticationType, load_agent_configs, AgentConfig, get_basic_auth_credentials, get_header_auth_headers
+from .loader import AuthenticationType, load_agent_configs, AgentConfig, get_basic_auth_credentials, get_header_auth_headers, get_ca_cert_from_secret
 from .child import create_child_agent
 from .parent import create_parent_agent, ChildAgent
 from fastapi import  WebSocket
@@ -186,10 +187,49 @@ def create_mcp_client(agent_config: AgentConfig, websocket: WebSocket | None = N
     }
     if os.environ.get('INSECURE_SKIP_TLS', 'false').lower() == "true":
         client_config["httpx_client_factory"] = _make_insecure_http_client
+        
+    elif agent_config.ca_bundle_ref:
+        try:
+            ca_pem = get_ca_cert_from_secret(
+                agent_config.ca_bundle_ref.name,
+                agent_config.ca_bundle_ref.key,
+            )
+            client_config["httpx_client_factory"] = _make_ca_httpx_factory(ca_pem)
+        except Exception as e:
+            logging.error(f"Failed to load CA cert from secret '{agent_config.ca_bundle_ref.name}': {e}")
+
 
     return MultiServerMCPClient({
         agent_config.name: client_config,
     })
+
+
+def _make_ca_httpx_factory(ca_pem: str):
+    """
+    Return an httpx_client_factory that trusts *both* the system CAs and
+    the supplied PEM-encoded CA certificate.
+
+    The factory follows the ``McpHttpClientFactory`` protocol expected by
+    ``langchain-mcp-adapters`` / the MCP Python SDK.
+    """
+    ctx = ssl.create_default_context()  # loads system CAs
+    ctx.load_verify_locations(cadata=ca_pem)
+
+    def factory(
+        headers: dict[str, str] | None = None,
+        timeout: httpx.Timeout | None = None,
+        auth: httpx.Auth | None = None,
+    ) -> httpx.AsyncClient:
+        kwargs: dict = {"follow_redirects": True, "verify": ctx}
+        if timeout is not None:
+            kwargs["timeout"] = timeout
+        if headers is not None:
+            kwargs["headers"] = headers
+        if auth is not None:
+            kwargs["auth"] = auth
+        return httpx.AsyncClient(**kwargs)
+
+    return factory
 
 
 async def _create_single_agent(

--- a/app/services/agent/factory.py
+++ b/app/services/agent/factory.py
@@ -6,7 +6,7 @@ from datetime import datetime, timezone
 import httpx
 from kubernetes import client, config
 from .root import create_root_agent
-from .loader import AuthenticationType, load_agent_configs, AgentConfig, get_basic_auth_credentials, get_header_auth_headers, get_ca_cert_from_secret
+from .loader import AuthenticationType, load_agent_configs, AgentConfig, get_basic_auth_credentials, get_header_auth_headers, get_ca_cert_from_secret, _load_k8s_config
 from .child import create_child_agent
 from .parent import create_parent_agent, ChildAgent
 from fastapi import  WebSocket
@@ -292,13 +292,7 @@ def _update_agent_status(agent_cfg: AgentConfig, is_ready: bool, reason: str, me
         return
     
     try:
-        # Load in-cluster config (works when running in a pod)
-        try:
-            config.load_incluster_config()
-        except config.ConfigException:
-            # Fall back to kubeconfig (for local development)
-            config.load_kube_config()
-        
+        _load_k8s_config()
         api = client.CustomObjectsApi()
         
         status = {

--- a/app/services/agent/loader.py
+++ b/app/services/agent/loader.py
@@ -2,6 +2,8 @@
 
 import logging
 import base64
+import os
+import urllib3
 
 from enum import Enum
 from typing import List, Optional
@@ -231,15 +233,23 @@ class AgentConfig(BaseModel):
     ready: bool = False
 
 
-def _init_k8s_client():
-    """Initialize Kubernetes client."""
+def _load_k8s_config():
+    """Load Kubernetes configuration, disabling SSL verification when INSECURE_SKIP_TLS is set."""
     try:
-        # Try in-cluster config first
         config.load_incluster_config()
     except config.ConfigException:
-        # Fall back to kubeconfig
         config.load_kube_config()
-    
+
+    if os.environ.get('INSECURE_SKIP_TLS', 'false').lower() == 'true':
+        configuration = client.Configuration.get_default_copy()
+        configuration.verify_ssl = False
+        client.Configuration.set_default(configuration)
+        urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+
+def _init_k8s_client():
+    """Initialize Kubernetes client."""
+    _load_k8s_config()
     return client.CustomObjectsApi()
 
 
@@ -253,11 +263,7 @@ def get_basic_auth_credentials(secret_name: str) -> str:
     Returns:
         str: Base64-encoded credentials in the format "username:password".
     """
-    # Initialize Kubernetes client
-    try:
-        config.load_incluster_config()
-    except config.ConfigException:
-        config.load_kube_config()
+    _load_k8s_config()
     
     v1 = client.CoreV1Api()
     secret = v1.read_namespaced_secret(secret_name, NAMESPACE)
@@ -328,10 +334,7 @@ def get_ca_cert_from_secret(secret_name: str, key: str = "ca.crt") -> str:
     Returns:
         str: PEM-encoded CA certificate.
     """
-    try:
-        config.load_incluster_config()
-    except config.ConfigException:
-        config.load_kube_config()
+    _load_k8s_config()
 
     v1 = client.CoreV1Api()
     secret = v1.read_namespaced_secret(secret_name, NAMESPACE)

--- a/app/services/agent/loader.py
+++ b/app/services/agent/loader.py
@@ -210,6 +210,12 @@ Examples: <suggestion>How do I scale a deployment?</suggestion><suggestion>Check
 """
 
 
+class CABundleRef(BaseModel):
+    """Reference to a CA certificate stored in a Kubernetes secret."""
+    name: str
+    key: str = "ca.crt"
+
+
 class AgentConfig(BaseModel):
     """Configuration for a single agent."""
     name: str 
@@ -219,6 +225,7 @@ class AgentConfig(BaseModel):
     mcp_url: str
     authentication: AuthenticationType = AuthenticationType.NONE
     authentication_secret: Optional[str] = None
+    ca_bundle_ref: Optional[CABundleRef] = None
     toolset: Optional[str] = None
     human_validation_tools: list[str] = []
     ready: bool = False
@@ -309,6 +316,40 @@ def get_header_auth_headers(secret_name: str) -> dict[str, str]:
     return headers
 
 
+def get_ca_cert_from_secret(secret_name: str, key: str = "ca.crt") -> str:
+    """
+    Retrieve a PEM-encoded CA certificate from a Kubernetes secret.
+
+    Args:
+        secret_name: Name of the secret containing the CA certificate.
+        key: The key inside the secret that holds the PEM data.
+             Defaults to ``ca.crt``.
+
+    Returns:
+        str: PEM-encoded CA certificate.
+    """
+    try:
+        config.load_incluster_config()
+    except config.ConfigException:
+        config.load_kube_config()
+
+    v1 = client.CoreV1Api()
+    secret = v1.read_namespaced_secret(secret_name, NAMESPACE)
+
+    if not secret.data:
+        raise RuntimeError(
+            f"CA secret '{secret_name}' in namespace '{NAMESPACE}' is empty"
+        )
+
+    if key not in secret.data:
+        raise RuntimeError(
+            f"CA secret '{secret_name}' in namespace '{NAMESPACE}' "
+            f"does not contain a '{key}' key"
+        )
+
+    return base64.b64decode(secret.data[key]).decode('utf-8')
+
+
 def _crd_to_agent_config(crd_obj: dict) -> AgentConfig:
     """Convert CRD object to AgentConfig."""
     metadata = crd_obj.get("metadata", {})
@@ -328,6 +369,7 @@ def _crd_to_agent_config(crd_obj: dict) -> AgentConfig:
         mcp_url=spec.get("mcpURL", ""),
         authentication=AuthenticationType[spec.get("authenticationType", "NONE")],
         authentication_secret=spec.get("authenticationSecret", None),
+        ca_bundle_ref=CABundleRef(**spec["caBundleRef"]) if spec.get("caBundleRef") else None,
         toolset=spec.get("toolSet", None),
         human_validation_tools=human_validation_tools,
         ready=status.get("phase", "Failed") == "Ready"
@@ -353,6 +395,10 @@ def _get_default_ai_agent_config_crds() -> list:
                 "authenticationType": "RANCHER",
                 "builtIn": True,
                 "enabled": True,
+                "caBundleRef": {
+                    "name": "cattle-mcp-ca",
+                    "key": "tls.crt"
+                },
                 "humanValidationTools": [
                     "createKubernetesResource", 
                     "patchKubernetesResource",
@@ -376,6 +422,10 @@ def _get_default_ai_agent_config_crds() -> list:
                 "authenticationType": "RANCHER",
                 "builtIn": True,
                 "enabled": True,
+                "caBundleRef": {
+                    "name": "cattle-mcp-ca",
+                    "key": "tls.crt"
+                },
             }
         },
         {
@@ -393,6 +443,10 @@ def _get_default_ai_agent_config_crds() -> list:
                 "authenticationType": "RANCHER",
                 "builtIn": True,
                 "enabled": True,
+                "caBundleRef": {
+                    "name": "cattle-mcp-ca",
+                    "key": "tls.crt"
+                },
                 "toolSet": "provisioning",
                 "humanValidationTools": [
                     "createImportedCluster",

--- a/chart/agent/templates/ai-agent-deployment.yaml
+++ b/chart/agent/templates/ai-agent-deployment.yaml
@@ -38,17 +38,10 @@ spec:
         emptyDir: {}
       - name: cert-dir
         emptyDir: {}
-      {{- if or (not .Values.insecureSkipTls) .Values.rag.pvc }}
-      {{- if not .Values.insecureSkipTls }}
-      - name: mcp-ca-volume
-        secret:
-          secretName: cattle-mcp-ca
-      {{- end }}
       {{- if .Values.rag.pvc }}
       - name: rag-storage
         persistentVolumeClaim:
           claimName: "{{ .Values.rag.pvc }}"
-      {{- end }}
       {{- end }}
       containers:
       - image: "{{ template "system_default_registry" . }}{{ .Values.aiAgent.image.repository }}:{{ .Values.aiAgent.image.tag }}"
@@ -180,14 +173,7 @@ spec:
           mountPath: /tmp
         - name: cert-dir
           mountPath: /cert
-        {{- if or (not .Values.insecureSkipTls) .Values.rag.pvc }}
-        {{- if not .Values.insecureSkipTls }}
-        - name: mcp-ca-volume
-          mountPath: /etc/tls
-          readOnly: true
-        {{- end }}
         {{- if .Values.rag.pvc }}
         - name: rag-storage
           mountPath: /app/rag
-        {{- end }}
         {{- end }}

--- a/chart/agent/templates/crds/ai.cattle.io_aiagentconfigs.yaml
+++ b/chart/agent/templates/crds/ai.cattle.io_aiagentconfigs.yaml
@@ -65,6 +65,22 @@ spec:
               builtIn:
                 description: BuiltIn indicates if this is a built-in agent configuration
                 type: boolean
+              caBundleRef:
+                description: CABundleRef references a secret key containing a
+                  PEM-encoded CA certificate bundle to trust when connecting to
+                  this agent's MCP server
+                properties:
+                  name:
+                    description: Name is the name of the secret in the agent namespace.
+                    type: string
+                  key:
+                    default: ca.crt
+                    description: Key is the key inside the secret that holds the
+                      data. Defaults to "ca.crt".
+                    type: string
+                required:
+                - name
+                type: object
               description:
                 description: Description provides details about the agent's purpose
                 type: string

--- a/crd-generation/api/v1alpha1/aiagentconfig_types.go
+++ b/crd-generation/api/v1alpha1/aiagentconfig_types.go
@@ -47,6 +47,25 @@ type AIAgentConfigSpec struct {
 	// ToolSet specifies a predefined set of tools for the agent
 	// +optional
 	ToolSet string `json:"toolSet,omitempty"`
+
+	// CABundleRef references a secret key containing a PEM-encoded CA
+	// certificate bundle to trust when connecting to this agent's MCP server.
+	// The CA is scoped to this agent's connection only.
+	// +optional
+	CABundleRef *SecretKeyRef `json:"caBundleRef,omitempty"`
+}
+
+// SecretKeyRef identifies a key within a Kubernetes secret.
+type SecretKeyRef struct {
+	// Name is the name of the secret in the agent namespace.
+	// +kubebuilder:validation:Required
+	Name string `json:"name"`
+
+	// Key is the key inside the secret that holds the data.
+	// Defaults to "ca.crt".
+	// +optional
+	// +kubebuilder:default="ca.crt"
+	Key string `json:"key,omitempty"`
 }
 
 // AIAgentConfigStatus defines the observed state of AIAgentConfig

--- a/tests/unit/services/agent/test_factory.py
+++ b/tests/unit/services/agent/test_factory.py
@@ -12,7 +12,8 @@ from app.services.agent.factory import (
     create_agent,
     NoAgentAvailableError,
     create_mcp_client,
-    _create_single_agent
+    _create_single_agent,
+    _make_ca_httpx_factory,
 )
 from app.services.agent.loader import AuthenticationType
 
@@ -596,3 +597,118 @@ def test_create_mcp_client_header_auth(mock_get_headers, mock_mcp_client):
     assert call_args["TestAgent"]["headers"]["X-Api-Key"] == "my-api-key"
     assert call_args["TestAgent"]["headers"]["Authorization"] == "Bearer tok123"
     mock_get_headers.assert_called_once_with("my-headers-secret")
+
+
+@patch('app.services.agent.factory._make_ca_httpx_factory')
+@patch('app.services.agent.factory.MultiServerMCPClient')
+@patch('app.services.agent.factory.get_ca_cert_from_secret')
+def test_create_mcp_client_with_ca_bundle_ref(mock_get_ca, mock_mcp_client, mock_make_factory):
+    """Verify create_mcp_client sets httpx_client_factory when caBundleRef is configured."""
+    mock_config = MagicMock()
+    mock_config.name = "TestAgent"
+    mock_config.authentication = AuthenticationType.NONE
+    mock_config.mcp_url = "https://mcp:8080"
+    ca_ref = MagicMock()
+    ca_ref.name = "my-ca-secret"
+    ca_ref.key = "ca.crt"
+    mock_config.ca_bundle_ref = ca_ref
+
+    mock_get_ca.return_value = "-----BEGIN CERTIFICATE-----\nFAKE\n-----END CERTIFICATE-----\n"
+    mock_factory = MagicMock()
+    mock_make_factory.return_value = mock_factory
+
+    mock_client_instance = MagicMock()
+    mock_mcp_client.return_value = mock_client_instance
+
+    result = create_mcp_client(mock_config)
+
+    assert result == mock_client_instance
+    mock_get_ca.assert_called_once_with("my-ca-secret", "ca.crt")
+    call_args = mock_mcp_client.call_args[0][0]
+    assert "httpx_client_factory" in call_args["TestAgent"]
+    assert call_args["TestAgent"]["httpx_client_factory"] == mock_factory
+
+
+@patch('app.services.agent.factory._make_ca_httpx_factory')
+@patch('app.services.agent.factory.MultiServerMCPClient')
+@patch('app.services.agent.factory.get_ca_cert_from_secret')
+def test_create_mcp_client_with_ca_bundle_ref_custom_key(mock_get_ca, mock_mcp_client, mock_make_factory):
+    """Verify create_mcp_client passes a custom key from caBundleRef."""
+    mock_config = MagicMock()
+    mock_config.name = "TestAgent"
+    mock_config.authentication = AuthenticationType.NONE
+    mock_config.mcp_url = "https://mcp:8080"
+    ca_ref = MagicMock()
+    ca_ref.name = "my-ca-secret"
+    ca_ref.key = "tls.crt"
+    mock_config.ca_bundle_ref = ca_ref
+
+    mock_get_ca.return_value = "-----BEGIN CERTIFICATE-----\nFAKE\n-----END CERTIFICATE-----\n"
+
+    mock_client_instance = MagicMock()
+    mock_mcp_client.return_value = mock_client_instance
+
+    create_mcp_client(mock_config)
+
+    mock_get_ca.assert_called_once_with("my-ca-secret", "tls.crt")
+
+
+@patch('app.services.agent.factory.MultiServerMCPClient')
+def test_create_mcp_client_without_ca_bundle_ref(mock_mcp_client):
+    """Verify create_mcp_client omits httpx_client_factory when no caBundleRef."""
+    mock_config = MagicMock()
+    mock_config.name = "TestAgent"
+    mock_config.authentication = AuthenticationType.NONE
+    mock_config.mcp_url = "https://mcp:8080"
+    mock_config.ca_bundle_ref = None
+
+    mock_client_instance = MagicMock()
+    mock_mcp_client.return_value = mock_client_instance
+
+    create_mcp_client(mock_config)
+
+    call_args = mock_mcp_client.call_args[0][0]
+    assert "httpx_client_factory" not in call_args["TestAgent"]
+
+
+@patch('app.services.agent.factory.MultiServerMCPClient')
+@patch('app.services.agent.factory.get_ca_cert_from_secret')
+def test_create_mcp_client_ca_bundle_ref_failure_logs_and_continues(mock_get_ca, mock_mcp_client):
+    """Verify create_mcp_client gracefully handles CA secret loading failure."""
+    mock_config = MagicMock()
+    mock_config.name = "TestAgent"
+    mock_config.authentication = AuthenticationType.NONE
+    mock_config.mcp_url = "https://mcp:8080"
+    ca_ref = MagicMock()
+    ca_ref.name = "bad-secret"
+    ca_ref.key = "ca.crt"
+    mock_config.ca_bundle_ref = ca_ref
+
+    mock_get_ca.side_effect = RuntimeError("secret not found")
+
+    mock_client_instance = MagicMock()
+    mock_mcp_client.return_value = mock_client_instance
+
+    result = create_mcp_client(mock_config)
+
+    # Should still return a client, just without custom CA
+    assert result == mock_client_instance
+    call_args = mock_mcp_client.call_args[0][0]
+    assert "httpx_client_factory" not in call_args["TestAgent"]
+
+
+def test_make_ca_httpx_factory_returns_async_client():
+    """Verify _make_ca_httpx_factory returns a factory that produces httpx.AsyncClient."""
+    import httpx
+    with patch('app.services.agent.factory.ssl') as mock_ssl:
+        mock_ctx = MagicMock()
+        mock_ssl.create_default_context.return_value = mock_ctx
+
+        factory = _make_ca_httpx_factory("FAKE-PEM")
+
+        mock_ssl.create_default_context.assert_called_once()
+        mock_ctx.load_verify_locations.assert_called_once_with(cadata="FAKE-PEM")
+
+        client = factory(headers={"X-Test": "val"}, timeout=httpx.Timeout(10))
+        assert isinstance(client, httpx.AsyncClient)
+        assert client._transport._pool._ssl_context == mock_ctx

--- a/tests/unit/services/agent/test_loader.py
+++ b/tests/unit/services/agent/test_loader.py
@@ -14,7 +14,7 @@ from app.services.agent.loader import (
     NAMESPACE,
 )
 
-from app.services.agent.loader import get_basic_auth_credentials, get_header_auth_headers, NAMESPACE
+from app.services.agent.loader import get_basic_auth_credentials, get_header_auth_headers, get_ca_cert_from_secret, NAMESPACE
 
 
 # ============================================================================
@@ -396,5 +396,109 @@ def test_get_header_auth_headers_api_exception(mock_k8s_client, mock_config):
 
     with pytest.raises(ApiException) as exc_info:
         get_header_auth_headers(secret_name)
+
+    assert exc_info.value.status == 404
+
+
+# ============================================================================
+# get_ca_cert_from_secret Tests
+# ============================================================================
+
+@patch('app.services.agent.loader.config')
+@patch('app.services.agent.loader.client')
+def test_get_ca_cert_from_secret_success(mock_k8s_client, mock_config):
+    """Verify get_ca_cert_from_secret successfully retrieves a PEM CA certificate."""
+    secret_name = "my-ca-secret"
+    ca_pem = "-----BEGIN CERTIFICATE-----\nMIIBxTCC...\n-----END CERTIFICATE-----\n"
+
+    mock_v1 = MagicMock()
+    mock_k8s_client.CoreV1Api.return_value = mock_v1
+
+    mock_secret = MagicMock()
+    mock_secret.data = {
+        'ca.crt': base64.b64encode(ca_pem.encode('utf-8')).decode('utf-8'),
+    }
+    mock_v1.read_namespaced_secret.return_value = mock_secret
+
+    result = get_ca_cert_from_secret(secret_name)
+
+    assert result == ca_pem
+    mock_v1.read_namespaced_secret.assert_called_once_with(secret_name, NAMESPACE)
+
+
+@patch('app.services.agent.loader.config')
+@patch('app.services.agent.loader.client')
+def test_get_ca_cert_from_secret_custom_key(mock_k8s_client, mock_config):
+    """Verify get_ca_cert_from_secret uses a custom key when provided."""
+    secret_name = "my-ca-secret"
+    ca_pem = "-----BEGIN CERTIFICATE-----\nCUSTOM\n-----END CERTIFICATE-----\n"
+
+    mock_v1 = MagicMock()
+    mock_k8s_client.CoreV1Api.return_value = mock_v1
+
+    mock_secret = MagicMock()
+    mock_secret.data = {
+        'tls.crt': base64.b64encode(ca_pem.encode('utf-8')).decode('utf-8'),
+    }
+    mock_v1.read_namespaced_secret.return_value = mock_secret
+
+    result = get_ca_cert_from_secret(secret_name, key="tls.crt")
+
+    assert result == ca_pem
+
+
+@patch('app.services.agent.loader.config')
+@patch('app.services.agent.loader.client')
+def test_get_ca_cert_from_secret_empty_secret(mock_k8s_client, mock_config):
+    """Verify get_ca_cert_from_secret raises RuntimeError for empty secret."""
+    secret_name = "empty-ca-secret"
+
+    mock_v1 = MagicMock()
+    mock_k8s_client.CoreV1Api.return_value = mock_v1
+
+    mock_secret = MagicMock()
+    mock_secret.data = None
+    mock_v1.read_namespaced_secret.return_value = mock_secret
+
+    with pytest.raises(RuntimeError) as exc_info:
+        get_ca_cert_from_secret(secret_name)
+
+    assert f"CA secret '{secret_name}'" in str(exc_info.value)
+    assert "is empty" in str(exc_info.value)
+
+
+@patch('app.services.agent.loader.config')
+@patch('app.services.agent.loader.client')
+def test_get_ca_cert_from_secret_missing_key(mock_k8s_client, mock_config):
+    """Verify get_ca_cert_from_secret raises RuntimeError when the requested key is missing."""
+    secret_name = "wrong-key-secret"
+
+    mock_v1 = MagicMock()
+    mock_k8s_client.CoreV1Api.return_value = mock_v1
+
+    mock_secret = MagicMock()
+    mock_secret.data = {
+        'tls.crt': base64.b64encode(b'some cert').decode('utf-8'),
+    }
+    mock_v1.read_namespaced_secret.return_value = mock_secret
+
+    with pytest.raises(RuntimeError) as exc_info:
+        get_ca_cert_from_secret(secret_name)
+
+    assert "does not contain a 'ca.crt' key" in str(exc_info.value)
+
+
+@patch('app.services.agent.loader.config')
+@patch('app.services.agent.loader.client')
+def test_get_ca_cert_from_secret_api_exception(mock_k8s_client, mock_config):
+    """Verify get_ca_cert_from_secret propagates ApiException from Kubernetes."""
+    secret_name = "nonexistent-secret"
+
+    mock_v1 = MagicMock()
+    mock_k8s_client.CoreV1Api.return_value = mock_v1
+    mock_v1.read_namespaced_secret.side_effect = ApiException(status=404, reason="Not Found")
+
+    with pytest.raises(ApiException) as exc_info:
+        get_ca_cert_from_secret(secret_name)
 
     assert exc_info.value.status == 404


### PR DESCRIPTION
## issue https://github.com/rancher/rancher-ai-agent/issues/180

- Load custom CA bundle from `AIAgentConfig` `caBundleRef` field
- Skip TLS validation for k8s client when `insecureSkipTls` is set

Usage
Add a `caBundleRef` to your `AIAgentConfig` spec pointing to a Kubernetes secret in the cattle-ai-agent-system `namespace` containing the CA cert:

```yaml
apiVersion: ai.cattle.io/v1alpha1
kind: AIAgentConfig
metadata:
  name: my-agent
  namespace: cattle-ai-agent-system
spec:
  caBundleRef:
    name: cattle-mcp-ca   # secret name
    key: tls.crt
```

The agent will trust both the system CAs and the custom CA when connecting to the MCP server. 

