### PR TITLE
fix: use httpx_client_factory to disable TLS verification instead of switching URL scheme

### DIFF
--- a/app/services/agent/factory.py
+++ b/app/services/agent/factory.py
@@ -2,6 +2,7 @@ import os
 import logging
 from datetime import datetime, timezone
 
+import httpx
 from kubernetes import client, config
 from .root import create_root_agent
 from .loader import AuthenticationType, load_agent_configs, AgentConfig, get_basic_auth_credentials
@@ -13,6 +14,15 @@ from langchain_mcp_adapters.client import MultiServerMCPClient
 from langgraph.graph.state import Checkpointer
 
 NAMESPACE = "cattle-ai-agent-system"
+
+
+def _make_insecure_http_client(
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None = None,
+    auth: httpx.Auth | None = None,
+) -> httpx.AsyncClient:
+    """httpx_client_factory that disables TLS certificate verification."""
+    return httpx.AsyncClient(headers=headers or {}, timeout=timeout, auth=auth, verify=False)
 
 
 class NoAgentAvailableError(Exception):
@@ -127,7 +137,7 @@ def create_mcp_client(agent_config: AgentConfig, websocket: WebSocket | None = N
     
     Note:
         - For Rancher authentication, extracts R_SESS cookie and uses RANCHER_URL
-        - Respects INSECURE_SKIP_TLS environment variable for HTTP/HTTPS selection
+        - Respects INSECURE_SKIP_TLS environment variable to disable TLS certificate verification
         - For BASIC authentication, encodes credentials in the Authorization header
         - For NONE authentication, creates client with no additional headers
     """
@@ -143,9 +153,7 @@ def create_mcp_client(agent_config: AgentConfig, websocket: WebSocket | None = N
             token = os.environ.get("RANCHER_API_TOKEN", "")
         
         mcp_url = os.environ.get("MCP_URL", agent_config.mcp_url)
-        if os.environ.get('INSECURE_SKIP_TLS', 'false').lower() == "true":
-            mcp_url = "http://" + mcp_url
-        else:
+        if not mcp_url.startswith(("http://", "https://")):
             mcp_url = "https://" + mcp_url
         headers = {
             "R_token": token,
@@ -164,12 +172,16 @@ def create_mcp_client(agent_config: AgentConfig, websocket: WebSocket | None = N
     else:
         mcp_url = agent_config.mcp_url
 
+    client_config: dict = {
+        "url": mcp_url,
+        "transport": "streamable_http",
+        "headers": headers,
+    }
+    if os.environ.get('INSECURE_SKIP_TLS', 'false').lower() == "true":
+        client_config["httpx_client_factory"] = _make_insecure_http_client
+
     return MultiServerMCPClient({
-        agent_config.name: {
-            "url": mcp_url,
-            "transport": "streamable_http",
-            "headers": headers,
-        },
+        agent_config.name: client_config,
     })
 
 

--- a/tests/unit/services/agent/test_factory.py
+++ b/tests/unit/services/agent/test_factory.py
@@ -407,7 +407,26 @@ def test_create_mcp_client_rancher_auth_with_websocket(mock_mcp_client):
 @patch('app.services.agent.factory.MultiServerMCPClient')
 @patch.dict(os.environ, {'INSECURE_SKIP_TLS': 'true', 'MCP_URL': 'mcp:8080'})
 def test_create_mcp_client_insecure(mock_mcp_client):
-    """Verify create_mcp_client respects INSECURE_SKIP_TLS."""
+    """Verify create_mcp_client respects INSECURE_SKIP_TLS by disabling TLS verification."""
+    mock_config = MagicMock()
+    mock_config.name = "TestAgent"
+    mock_config.authentication = AuthenticationType.RANCHER
+    mock_config.mcp_url = "mcp-service:8080"
+
+    mock_client_instance = MagicMock()
+    mock_mcp_client.return_value = mock_client_instance
+
+    result = create_mcp_client(mock_config)
+
+    call_args = mock_mcp_client.call_args[0][0]
+    assert call_args["TestAgent"]["url"] == "https://mcp:8080"
+    assert call_args["TestAgent"]["httpx_client_factory"] is not None
+
+
+@patch('app.services.agent.factory.MultiServerMCPClient')
+@patch.dict(os.environ, {'INSECURE_SKIP_TLS': 'true', 'MCP_URL': 'https://mcp:8080'})
+def test_create_mcp_client_insecure_with_existing_scheme(mock_mcp_client):
+    """Verify create_mcp_client preserves an existing URL scheme."""
     mock_config = MagicMock()
     mock_config.name = "TestAgent"
     mock_config.authentication = AuthenticationType.RANCHER
@@ -419,7 +438,8 @@ def test_create_mcp_client_insecure(mock_mcp_client):
     result = create_mcp_client(mock_config)
     
     call_args = mock_mcp_client.call_args[0][0]
-    assert call_args["TestAgent"]["url"].startswith("http://")
+    assert call_args["TestAgent"]["url"] == "https://mcp:8080"
+    assert call_args["TestAgent"]["httpx_client_factory"] is not None
 
 
 @patch('app.services.agent.factory.MultiServerMCPClient')


### PR DESCRIPTION
Previously, `INSECURE_SKIP_TLS` and `AuthenticationType.RANCHER` caused the MCP URL to be prefixed with `http://` always, which broke when the URL already contained a scheme. Now the URL scheme is left untouched (defaulting to `https://` only when no scheme is present), and TLS verification is disabled by passing a custom httpx_client_factory with `verify=False` to MultiServerMCPClient.