### PR TITLE
Handle updateKubernetesResource_plan tool errors

### DIFF
--- a/app/services/agent/base.py
+++ b/app/services/agent/base.py
@@ -25,8 +25,8 @@ INTERRUPT_PREVIOUS_TOOL_FAILED_MESSAGE = "tool execution cancelled because previ
 MAX_CONSECUTIVE_TOOL_CALLS = 5
 
 
-class InterruptError(Exception):
-    """Exception raised when interrupt message generation fails."""
+class InterruptToolException(Exception):
+    """Exception raised when invoking a tool that should trigger an interrupt."""
     pass
 
 class BaseAgentBuilder:
@@ -536,7 +536,7 @@ You are a highly specialized Assistant. Your primary goal is to provide accurate
             
             try:
                 should_continue, interrupt_message, ui_tools_list = await self.handle_interrupt(human_validation_tools, tool_call, state, config)
-            except InterruptedError as e:
+            except InterruptToolException as e:
                 logging.error(f"Error during confirmation interrupt: {e}")
                 interrupt_messages[tool_call["id"]] = {
                     "message": f"{e}",
@@ -717,7 +717,7 @@ You are a highly specialized Assistant. Your primary goal is to provide accurate
                     plan_response = await plan_tool.ainvoke(tool_call["args"])
                 except Exception as e:
                     logging.error(f"error invoking planning tool '{plan_tool_name}' for interrupt: {e}")
-                    raise Exception(e)
+                    raise InterruptToolException(e)
 
                 # Normalize list response from MCP tools: [{"type": "text", "text": "..."}]
                 if isinstance(plan_response, list) and len(plan_response) > 0:
@@ -752,9 +752,9 @@ You are a highly specialized Assistant. Your primary goal is to provide accurate
 
         try:
             interrupt_message = await self.should_interrupt(human_validation_tools, tool_call)
-        except Exception as e:
+        except InterruptToolException as e:
             logging.error(f"Error during interrupt message generation: {e}")
-            raise InterruptedError(e)
+            raise e
 
         if interrupt_message:
             logging.info(f"Confirmation interrupt triggered for tool '{tool_call.get('name')}', config={'present' if config else 'missing'}")

--- a/app/services/agent/base.py
+++ b/app/services/agent/base.py
@@ -24,6 +24,11 @@ INTERRUPT_CANCEL_MESSAGE = "tool execution cancelled by the user"
 INTERRUPT_PREVIOUS_TOOL_FAILED_MESSAGE = "tool execution cancelled because previous tool call failed"
 MAX_CONSECUTIVE_TOOL_CALLS = 5
 
+
+class InterruptError(Exception):
+    """Exception raised when interrupt message generation fails."""
+    pass
+
 class BaseAgentBuilder:
     """Base class for agent builders with shared logic."""
     
@@ -727,51 +732,60 @@ You are a highly specialized Assistant. Your primary goal is to provide accurate
             - interrupt_message: The interrupt message if one was triggered, None otherwise
             - ui_tools_list: List of UI tools for this confirmation, empty if none
         """
-        ui_tools_list = []
-        
-        if interrupt_message := await self.should_interrupt(human_validation_tools, tool_call):
+        interrupt_message = None
+
+        try:
+            interrupt_message = await self.should_interrupt(human_validation_tools, tool_call)
+        except Exception as e:
+            logging.error(f"Error during interrupt message generation: {e}")
+            raise InterruptedError(e)
+
+        if interrupt_message:
             logging.info(f"Confirmation interrupt triggered for tool '{tool_call.get('name')}', config={'present' if config else 'missing'}")
             
-            if interrupt_message:
-                # Dispatch UI tools before the interrupt, so they're available to the client
-                if config is not None:
-                    try:
-                        data = json.loads(interrupt_message.strip('<confirmation-response></confirmation-response>'))
-                        if isinstance(data, list) and len(data) > 0:
-                            data = data[0]
-                            
-                        # Build ui tool
-                        resource = data.get("resource", {})
-                        input = {
-                            "resourceKind": resource.get("kind"),
-                            "resourceName": resource.get("name"),
-                            "resourceNamespace": resource.get("namespace"),
-                        }
-                        ui_tool_name = "show-yaml"
-
-                        if data.get("type") == "create":
-                            input["yaml"] = data.get("payload", {})
-                        else:
-                            ui_tool_name = "show-yaml-diff"
-                            input["original"] = data.get("payload", {}).get("original")
-                            input["patched"] = data.get("payload", {}).get("patched")
-
-                        input = {k: v for k, v in input.items() if v is not None}
-                        
-                        ui_tools_list = [{
-                            "toolName": ui_tool_name,
-                            "input": input,
-                        }]
-                        self._dispatch_preprocessed_ui_tools(state, config, ui_tools_list)
-                    except Exception as e:
-                        logging.debug(f"Could not extract precomputed fields from interrupt message and dispatch UI tools: {e}")
-
-                else:
-                    logging.warning("config is None, cannot dispatch UI tools before confirmation")
+            ui_tools_list = []
             
-            response = langgraph.types.interrupt(interrupt_message)
+            # Dispatch UI tools before the interrupt, so they're available to the client
+            if config is not None:
+                try:
+                    data = json.loads(interrupt_message)
+                    if isinstance(data, list) and len(data) > 0:
+                        data = data[0]
+                        
+                    # Build ui tool
+                    resource = data.get("resource", {})
+                    input = {
+                        "resourceKind": resource.get("kind"),
+                        "resourceName": resource.get("name"),
+                        "resourceNamespace": resource.get("namespace"),
+                    }
+                    ui_tool_name = "show-yaml"
+
+                    if data.get("type") == "create":
+                        input["yaml"] = data.get("payload", {})
+                    else:
+                        ui_tool_name = "show-yaml-diff"
+                        input["original"] = data.get("payload", {}).get("original")
+                        input["patched"] = data.get("payload", {}).get("patched")
+
+                    input = {k: v for k, v in input.items() if v is not None}
+                    
+                    ui_tools_list = [{
+                        "toolName": ui_tool_name,
+                        "input": input,
+                    }]
+                    self._dispatch_preprocessed_ui_tools(state, config, ui_tools_list)
+                except Exception as e:
+                    logging.debug(f"Could not extract precomputed fields from interrupt message and dispatch UI tools: {e}")
+
+            else:
+                logging.warning("config is None, cannot dispatch UI tools before confirmation")
+            
+            interrupt_message_result = build_interrupt_message_result(interrupt_message)
+
+            response = langgraph.types.interrupt(interrupt_message_result)
             if response != "yes":
-                return False, interrupt_message, ui_tools_list
+                return False, interrupt_message_result, ui_tools_list
             
             selected_agent = state.get("selected_agent", {})
             if selected_agent:
@@ -779,9 +793,9 @@ You are a highly specialized Assistant. Your primary goal is to provide accurate
                     "subagent_choice_event",
                     build_agent_metadata(selected_agent.get("name"), selected_agent.get("mode")),
                 )
-            return True, interrupt_message, ui_tools_list
+            return True, interrupt_message_result, ui_tools_list
             
-        return True, None, ui_tools_list 
+        return True, None, []
 
 
 
@@ -821,6 +835,10 @@ def process_tool_result(tool_result: str | list, state: AgentState) -> tuple[str
     except (json.JSONDecodeError, TypeError):
         # If it's not a valid JSON, return the raw string result
         return tool_result, mcp_response
+    
+def build_interrupt_message_result(interrupt_message) -> str:
+    """Builds the interrupt message content based on the tool call and its planning response."""
+    return f"<confirmation-response>{interrupt_message}</confirmation-response>"
 
 
 def convert_to_string_if_needed(var):

--- a/app/services/agent/base.py
+++ b/app/services/agent/base.py
@@ -692,7 +692,11 @@ You are a highly specialized Assistant. Your primary goal is to provide accurate
                 plan_tool = self.planning_tools_by_name.get(plan_tool_name)
                 if plan_tool is None:
                     raise ValueError(f"planning tool '{plan_tool_name}' not found for tool '{tool_call['name']}'")
-                plan_response = await plan_tool.ainvoke(tool_call["args"])
+                try:
+                    plan_response = await plan_tool.ainvoke(tool_call["args"])
+                except Exception as e:
+                    logging.error(f"error invoking planning tool '{plan_tool_name}' for interrupt: {e}")
+                    raise Exception(e)
 
                 # Normalize list response from MCP tools: [{"type": "text", "text": "..."}]
                 if isinstance(plan_response, list) and len(plan_response) > 0:
@@ -703,7 +707,8 @@ You are a highly specialized Assistant. Your primary goal is to provide accurate
                     safe_response = json.dumps(json.loads(plan_response))
                 except (json.JSONDecodeError, TypeError):
                     safe_response = json.dumps(plan_response)
-                return f'<confirmation-response>{safe_response}</confirmation-response>'
+
+                return safe_response
 
         return ""
 

--- a/app/services/agent/base.py
+++ b/app/services/agent/base.py
@@ -532,7 +532,19 @@ You are a highly specialized Assistant. Your primary goal is to provide accurate
         # responses first ensures every tool is executed exactly once.
         interrupt_messages = {}
         for idx, tool_call in enumerate(tool_calls):
-            should_continue, interrupt_message, ui_tools_list = await self.handle_interrupt(human_validation_tools, tool_call, state, config)
+            should_continue, interrupt_message, ui_tools_list = None, None, []
+            
+            try:
+                should_continue, interrupt_message, ui_tools_list = await self.handle_interrupt(human_validation_tools, tool_call, state, config)
+            except InterruptedError as e:
+                logging.error(f"Error during confirmation interrupt: {e}")
+                interrupt_messages[tool_call["id"]] = {
+                    "message": f"{e}",
+                    "ui_tools": [],
+                    "interrupt-error": True
+                }
+                break
+
             if not should_continue:
                 # Cancel ALL tool calls: previously approved ones, the rejected one,
                 # and any remaining unevaluated ones — no tools will be executed.
@@ -558,7 +570,7 @@ You are a highly specialized Assistant. Your primary goal is to provide accurate
                     "ui_tools": ui_tools_list
                 }
 
-        # Phase 2: Execute tools (all interrupts were approved if we reach here).
+        # Phase 2: Execute tools (all interrupts were approved OR interrupt errors occurred if we reach here).
         for idx, tool_call in enumerate(tool_calls):
             additional_kwargs = {
                 "request_id": request_id,
@@ -572,6 +584,10 @@ You are a highly specialized Assistant. Your primary goal is to provide accurate
                 additional_kwargs["ui_tools"] = interrupt_message["ui_tools"]
             
             try:
+                # Skip execution and return the exception as information for the next nodes to handle
+                if interrupt_message and interrupt_message.get("interrupt-error", False):
+                    raise ToolException(interrupt_message['message'])
+
                 logging.debug("calling tool")
                 tool_result = await self.tools_by_name[tool_call["name"]].ainvoke(tool_call["args"])
                 logging.debug("tool call finished")

--- a/tests/unit/services/agent/test_base_agent.py
+++ b/tests/unit/services/agent/test_base_agent.py
@@ -8,6 +8,7 @@ import json
 
 from unittest.mock import AsyncMock, MagicMock, patch
 from app.services.agent.base import (
+    InterruptToolException,
     process_tool_result,
     convert_to_string_if_needed,
     INTERRUPT_CANCEL_MESSAGE,
@@ -1039,7 +1040,7 @@ async def test_should_interrupt_raises_exception_when_planning_tool_fails(mock_l
 
 @pytest.mark.asyncio
 async def test_handle_interrupt_catches_planning_tool_failure(mock_llm, mock_checkpointer):
-    """Verify handle_interrupt catches and wraps planning tool failure as InterruptedError."""
+    """Verify handle_interrupt catches and wraps planning tool failure as InterruptToolException."""
     validation_tools = ["testTool"]
     
     # Create a mock plan tool that fails
@@ -1061,8 +1062,8 @@ async def test_handle_interrupt_catches_planning_tool_failure(mock_llm, mock_che
         "args": {"test": "arg"}
     }
     
-    # handle_interrupt should catch the exception and raise InterruptedError
-    with pytest.raises(InterruptedError):
+    # handle_interrupt should catch the exception and raise InterruptToolException
+    with pytest.raises(InterruptToolException):
         await builder.handle_interrupt(validation_tools, tool_call, {})
 
 @pytest.mark.asyncio

--- a/tests/unit/services/agent/test_base_agent.py
+++ b/tests/unit/services/agent/test_base_agent.py
@@ -917,7 +917,6 @@ async def test_should_interrupt_returns_message_for_update_tools(mock_llm, mock_
     
     result = await builder.should_interrupt(validation_tools, tool_call)
     
-    assert "<confirmation-response>" in result
     assert "plan response for patching" in result
 
 @pytest.mark.asyncio
@@ -973,6 +972,7 @@ async def test_handle_interrupt_cancels_on_no_response(mock_llm, mock_checkpoint
     
     assert should_continue is False
     assert interrupt_msg is not None
+    assert "<confirmation-response>" in interrupt_msg
 
 @pytest.mark.asyncio
 async def test_handle_interrupt_continues_on_yes_response(mock_llm, mock_checkpointer):
@@ -1005,6 +1005,112 @@ async def test_handle_interrupt_continues_on_yes_response(mock_llm, mock_checkpo
     
     assert should_continue is True
     assert interrupt_msg is not None
+    assert "<confirmation-response>" in interrupt_msg
+
+@pytest.mark.asyncio
+async def test_should_interrupt_raises_exception_when_planning_tool_fails(mock_llm, mock_checkpointer):
+    """Verify should_interrupt raises exception when planning tool fails."""
+    validation_tools = ["testTool"]
+    
+    # Create a mock plan tool that fails
+    failing_plan_tool = MockTool("testToolPlan", "should fail")
+    failing_plan_tool.ainvoke = AsyncMock(side_effect=ValueError("Planning tool error"))
+    
+    regular_tool = MockTool("testTool", "result")
+
+    builder = BaseAgentBuilder(
+        llm=mock_llm,
+        tools=[regular_tool, failing_plan_tool],
+        system_prompt="system_prompt",
+        checkpointer=mock_checkpointer,
+        agent_config=MagicMock()
+    )
+
+    tool_call = {
+        "name": "testTool",
+        "args": {"test": "arg"}
+    }
+    
+    # should_interrupt should raise an exception when planning tool fails
+    with pytest.raises(Exception) as exc_info:
+        await builder.should_interrupt(validation_tools, tool_call)
+    
+    assert "Planning tool error" in str(exc_info.value)
+
+@pytest.mark.asyncio
+async def test_handle_interrupt_catches_planning_tool_failure(mock_llm, mock_checkpointer):
+    """Verify handle_interrupt catches and wraps planning tool failure as InterruptedError."""
+    validation_tools = ["testTool"]
+    
+    # Create a mock plan tool that fails
+    failing_plan_tool = MockTool("testToolPlan", "should fail")
+    failing_plan_tool.ainvoke = AsyncMock(side_effect=ValueError("Planning tool failed"))
+    
+    regular_tool = MockTool("testTool", "result")
+
+    builder = BaseAgentBuilder(
+        llm=mock_llm,
+        tools=[regular_tool, failing_plan_tool],
+        system_prompt="system_prompt",
+        checkpointer=mock_checkpointer,
+        agent_config=MagicMock()
+    )
+
+    tool_call = {
+        "name": "testTool",
+        "args": {"test": "arg"}
+    }
+    
+    # handle_interrupt should catch the exception and raise InterruptedError
+    with pytest.raises(InterruptedError):
+        await builder.handle_interrupt(validation_tools, tool_call, {})
+
+@pytest.mark.asyncio
+async def test_tool_node_handles_planning_tool_failure_error(mock_llm, mock_tools, mock_checkpointer, mock_config, agent_config_with_validation):
+    """Verify tool_node handles planning tool failures and stores error flag."""
+    failing_plan_tool = MockTool("patchKubernetesResourcePlan", "should fail")
+    failing_plan_tool.ainvoke = AsyncMock(side_effect=ValueError("Planning tool failed"))
+    
+    builder = BaseAgentBuilder(
+        llm=mock_llm,
+        tools=mock_tools + [failing_plan_tool],
+        system_prompt="system_prompt",
+        checkpointer=mock_checkpointer,
+        agent_config=agent_config_with_validation
+    )
+
+    # Create state with a tool call that requires validation
+    ai_message = AIMessage(
+        content="",
+        tool_calls=[
+            {
+                "id": "call_1",
+                "name": "patchKubernetesResource",
+                "args": {
+                    "patch": "[]",
+                    "name": "test",
+                    "kind": "Pod",
+                    "cluster": "local",
+                    "namespace": "default"
+                }
+            }
+        ]
+    )
+    state = {"messages": [ai_message]}
+    
+    result = await builder.tool_node(state, mock_config)
+    
+    # The result should contain a ToolMessage with error information
+    assert "messages" in result
+    tool_messages = result["messages"]
+    assert len(tool_messages) > 0
+    
+    # Check that the error is flagged
+    last_message = tool_messages[-1]
+    if isinstance(last_message, ToolMessage):
+        additional_kwargs = last_message.additional_kwargs or {}
+        # Should have the interrupt-error flag or error content
+        assert "interrupt-error" in additional_kwargs or "error" in last_message.content.lower()
 
 def test_process_tool_result_handles_mcp_response_with_ui_context():
     """Verify MCP responses with uiContext are properly extracted."""


### PR DESCRIPTION
Fixes https://github.com/rancher/rancher-ai-agent/issues/191

When a tool's confirmation is executed with the Rancher agent, for instance the user asks for updating a pod, the `updateKubernetesResourcePlan` is called to prepare and send a confirmation request.

The tool can return errors, for instance when the resource to update [doesn't exist](https://github.com/rancher/rancher-ai-mcp/blob/812e61697818022c3e1417d48a324310c846bb0c/pkg/toolsets/core/patch_resource_plan.go#L32):

We are not catching those errors.

### Proposed solution:

- Catch the errors when invoking the `plan` tools
- In case of errors:
  - Cancel pending requests
  - DO NOT execute the action
  - Continue with the workflow to allow langraph to invoke the next node and the llm to send a response to the user, explaining what happened.
  
### Screenshots
 
Before

  https://github.com/user-attachments/assets/9ab75bd8-bc69-4ade-913e-3270f04d6e4b

After


https://github.com/user-attachments/assets/73d2c099-ff2a-4cbd-b6a6-4c0e1f53c10a



