### PR TITLE
Remove unnecessary logs

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -66,7 +66,8 @@ NOISY_LOGGERS = [
     "botocore",
     "boto3",
     "asyncio",
-    "mcp.client.streamable_http"
+    "mcp.client.streamable_http",
+    "openai._base_client"
 ]
 
 @asynccontextmanager

--- a/app/routers/configuration.py
+++ b/app/routers/configuration.py
@@ -306,8 +306,6 @@ async def update_settings(settings: SettingsUpdate, request: Request):
                 content={"detail": f"User does not have permission to update settings in namespace {AGENT_NAMESPACE}"}
             )
 
-        logging.debug(f"User is updating settings: {settings}")
-
         # Validate settings based on ACTIVE_CHATBOT
         updated_fields = settings.model_dump(exclude_none=True)
         active_chatbot = updated_fields.get("ACTIVE_LLM")


### PR DESCRIPTION
When LOG_LEVEL is set to DEBUG, a lot of noisy, useless logs appear. This PR removes them.