### PR TITLE
MCP NetworkPolicy

### DIFF
--- a/chart/agent/templates/mcp-network-policy.yaml
+++ b/chart/agent/templates/mcp-network-policy.yaml
@@ -14,20 +14,3 @@ spec:
         - podSelector:
             matchLabels:
               app: rancher-ai-agent
----
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
-metadata:
-  name: rancher-ai-agent-ingress
-  namespace: cattle-ai-agent-system
-spec:
-  podSelector:
-    matchLabels:
-      app: rancher-ai-agent
-  policyTypes:
-    - Ingress
-  ingress:
-    - from:
-        - podSelector:
-            matchLabels:
-              app: rancher-mcp-server

--- a/chart/agent/templates/mcp-network-policy.yaml
+++ b/chart/agent/templates/mcp-network-policy.yaml
@@ -1,24 +1,33 @@
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: rancher-mcp-server
+  name: rancher-mcp-server-ingress
   namespace: cattle-ai-agent-system
-  labels:
-    app: rancher-mcp-server
 spec:
   podSelector:
     matchLabels:
       app: rancher-mcp-server
   policyTypes:
     - Ingress
-    - Egress
   ingress:
     - from:
         - podSelector:
             matchLabels:
               app: rancher-ai-agent
-  egress:
-    - to:
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: rancher-ai-agent-ingress
+  namespace: cattle-ai-agent-system
+spec:
+  podSelector:
+    matchLabels:
+      app: rancher-ai-agent
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
         - podSelector:
             matchLabels:
-              app: rancher-ai-agent
+              app: rancher-mcp-server

--- a/chart/agent/templates/mcp-network-policy.yaml
+++ b/chart/agent/templates/mcp-network-policy.yaml
@@ -1,0 +1,24 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: rancher-mcp-server
+  namespace: cattle-ai-agent-system
+  labels:
+    app: rancher-mcp-server
+spec:
+  podSelector:
+    matchLabels:
+      app: rancher-mcp-server
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app: rancher-ai-agent
+  egress:
+    - to:
+        - podSelector:
+            matchLabels:
+              app: rancher-ai-agent


### PR DESCRIPTION
Issue https://github.com/rancher/rancher-ai-agent/issues/210

The `NetworkPolicy` restricts the `rancher-mcp-server` pod so that:

-Ingress: only allows traffic from pods with label app: `rancher-ai-agent` 
-Egress: only allows traffic to pods with label app: `rancher-ai-agent` 

All other inbound and outbound traffic to/from the MCP pod will be denied.