### PR TITLE
Move gemini-3.1-flash-lite-preview to gemini-3.1-flash-lite

### DIFF
--- a/app/routers/configuration.py
+++ b/app/routers/configuration.py
@@ -41,7 +41,7 @@ AVAILABLE_MODELS = {
     ],
     "gemini": [
         "gemini-3-flash-preview",
-        "gemini-3.1-flash-lite-preview",
+        "gemini-3.1-flash-lite",
         "gemini-3.1-pro-preview",
         "gemini-2.5-pro",
         "gemini-2.5-flash",


### PR DESCRIPTION
gemini-3.1-flash-lite-preview is deprecated; it's recommended to switch to gemini-3.1-flash-lite.


https://ai.google.dev/gemini-api/docs/models/gemini-3.1-flash-lite-preview

Note: Using `gemini-3.1-flash-lite-preview` still works.
