### PR TITLE
fix(controller): retry transient MCP connection failures with exponential backoff

### DIFF
--- a/app/controllers/ai_agent_config.py
+++ b/app/controllers/ai_agent_config.py
@@ -9,11 +9,29 @@ import asyncio
 import logging
 import threading
 import kopf
+import httpx
 
 from kopf._cogs.configs.configuration import ScanningSettings, PostingSettings
 from datetime import datetime, timezone
 from ..services.agent.loader import AgentConfig, CABundleRef
 from ..services.agent.factory import create_mcp_client
+
+# Transient exception types that indicate the MCP server may not be ready yet.
+# These warrant a retry with backoff rather than a permanent failure.
+_TRANSIENT_EXCEPTIONS = (
+    ConnectionError,        # ConnectionRefusedError, ConnectionResetError, etc.
+    TimeoutError,
+    OSError,                # Low-level socket errors (e.g. "Network unreachable")
+    httpx.ConnectError,
+    httpx.ConnectTimeout,
+    httpx.ReadTimeout,
+    httpx.WriteTimeout,
+    httpx.PoolTimeout,
+)
+
+_INITIAL_RETRY_DELAY = 1
+_MAX_RETRY_DELAY = 300
+_MAX_RETRIES = 50
 
 
 class KopfManager:
@@ -158,7 +176,7 @@ async def _validate(agent_config: AgentConfig) -> None:
 @kopf.on.resume('ai.cattle.io', 'v1alpha1', 'aiagentconfigs', field='spec')
 @kopf.on.create('ai.cattle.io', 'v1alpha1', 'aiagentconfigs', field='spec')
 @kopf.on.update('ai.cattle.io', 'v1alpha1', 'aiagentconfigs', field='spec')
-async def create_fn(spec, name, namespace, logger, patch, **kwargs):
+async def create_fn(spec, name, namespace, logger, patch, retry, **kwargs):
     """
     Handle AIAgentConfig resource lifecycle events.
     
@@ -205,6 +223,18 @@ async def create_fn(spec, name, namespace, logger, patch, **kwargs):
         # Update status to reflect the failure
         _set_status(patch, False, 'ConfigurationFailed', error_msg)
         logger.warning(error_msg)
+
+        # If any exception in the group is transient, retry with exponential backoff
+        if any(isinstance(e, _TRANSIENT_EXCEPTIONS) for e in eg.exceptions):
+            if retry >= _MAX_RETRIES:
+                raise kopf.PermanentError(
+                    f"Failed to load MCP tools after {retry} retries: {error_message}"
+                )
+            delay = min(_INITIAL_RETRY_DELAY * (2 ** retry), _MAX_RETRY_DELAY)
+            raise kopf.TemporaryError(
+                f"Failed to load MCP tools (retry {retry + 1}/{_MAX_RETRIES}): {error_message}",
+                delay=delay,
+            )
 
         raise kopf.PermanentError(f"Failed to load MCP tools: {error_message}") 
         

--- a/tests/unit/controllers/test_ai_agent_config.py
+++ b/tests/unit/controllers/test_ai_agent_config.py
@@ -1,0 +1,206 @@
+"""
+Unit tests for the AIAgentConfig kopf controller.
+
+Tests transient vs permanent error classification and retry behaviour.
+"""
+import pytest
+import httpx
+import kopf
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from app.controllers.ai_agent_config import (
+    create_fn,
+    _INITIAL_RETRY_DELAY,
+    _MAX_RETRY_DELAY,
+    _MAX_RETRIES,
+)
+
+
+def _make_spec(**overrides):
+    """Return a minimal valid spec dict."""
+    base = {
+        "displayName": "Test Agent",
+        "description": "desc",
+        "systemPrompt": "prompt",
+        "mcpURL": "http://mcp:8080/sse",
+        "authenticationType": "NONE",
+        "authenticationSecret": "",
+    }
+    base.update(overrides)
+    return base
+
+
+def _build_kwargs(spec=None, retry=0):
+    """Return the keyword arguments for invoking create_fn."""
+    return dict(
+        spec=spec or _make_spec(),
+        name="test-agent",
+        namespace="cattle-ai-agent-system",
+        logger=MagicMock(),
+        patch=MagicMock(status={}),
+        retry=retry,
+    )
+
+
+# ============================================================================
+# Successful validation
+# ============================================================================
+
+@pytest.mark.asyncio
+@patch("app.controllers.ai_agent_config._validate", new_callable=AsyncMock)
+async def test_create_fn_success(mock_validate):
+    """Handler sets phase=Ready when validation succeeds."""
+    kwargs = _build_kwargs()
+    await create_fn(**kwargs)
+
+    mock_validate.assert_awaited_once()
+    patch_obj = kwargs["patch"]
+    assert patch_obj.status["phase"] == "Ready"
+    assert patch_obj.status["conditions"][0]["status"] == "True"
+
+
+# ============================================================================
+# Transient errors → kopf.TemporaryError with exponential backoff
+# ============================================================================
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "exc_class",
+    [
+        ConnectionRefusedError,
+        ConnectionResetError,
+        TimeoutError,
+        OSError,
+        httpx.ConnectError,
+        httpx.ConnectTimeout,
+        httpx.ReadTimeout,
+    ],
+    ids=lambda c: c.__name__,
+)
+@patch("app.controllers.ai_agent_config._validate", new_callable=AsyncMock)
+async def test_transient_error_raises_temporary(mock_validate, exc_class):
+    """Transient connection errors should raise TemporaryError with a retry delay."""
+    if issubclass(exc_class, (httpx.ConnectError, httpx.ConnectTimeout, httpx.ReadTimeout)):
+        exc = exc_class("connection failed", request=MagicMock())
+    else:
+        exc = exc_class("connection failed")
+    mock_validate.side_effect = ExceptionGroup("eg", [exc])
+
+    kwargs = _build_kwargs(retry=0)
+    with pytest.raises(kopf.TemporaryError) as exc_info:
+        await create_fn(**kwargs)
+
+    assert exc_info.value.delay == _INITIAL_RETRY_DELAY
+    patch_obj = kwargs["patch"]
+    assert patch_obj.status["phase"] == "Failed"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "retry,expected_delay",
+    [
+        (0, _INITIAL_RETRY_DELAY),        # 1s
+        (1, _INITIAL_RETRY_DELAY * 2),    # 2s
+        (2, _INITIAL_RETRY_DELAY * 4),    # 4s
+        (4, _INITIAL_RETRY_DELAY * 16),   # 16s
+        (8, _INITIAL_RETRY_DELAY * 256),  # 256s
+        (9, _MAX_RETRY_DELAY),            # capped at 300s
+        (49, _MAX_RETRY_DELAY),           # still capped
+    ],
+)
+@patch("app.controllers.ai_agent_config._validate", new_callable=AsyncMock)
+async def test_exponential_backoff(mock_validate, retry, expected_delay):
+    """Retry delay doubles each attempt, capped at _MAX_RETRY_DELAY."""
+    mock_validate.side_effect = ExceptionGroup(
+        "eg", [ConnectionRefusedError("refused")]
+    )
+
+    kwargs = _build_kwargs(retry=retry)
+    with pytest.raises(kopf.TemporaryError) as exc_info:
+        await create_fn(**kwargs)
+
+    assert exc_info.value.delay == expected_delay
+
+
+@pytest.mark.asyncio
+@patch("app.controllers.ai_agent_config._validate", new_callable=AsyncMock)
+async def test_max_retries_exceeded_becomes_permanent(mock_validate):
+    """After _MAX_RETRIES transient failures, raise PermanentError."""
+    mock_validate.side_effect = ExceptionGroup(
+        "eg", [ConnectionRefusedError("refused")]
+    )
+
+    kwargs = _build_kwargs(retry=_MAX_RETRIES)
+    with pytest.raises(kopf.PermanentError) as exc_info:
+        await create_fn(**kwargs)
+
+    assert "after" in str(exc_info.value).lower()
+
+
+# ============================================================================
+# Permanent errors → kopf.PermanentError
+# ============================================================================
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "exc_class,exc_args",
+    [
+        (ValueError, ("malformed URL",)),
+        (KeyError, ("missing-key",)),
+        (RuntimeError, ("unrecoverable",)),
+    ],
+    ids=lambda c: str(c),
+)
+@patch("app.controllers.ai_agent_config._validate", new_callable=AsyncMock)
+async def test_permanent_error_raises_permanent(mock_validate, exc_class, exc_args):
+    """Non-transient errors should raise PermanentError."""
+    mock_validate.side_effect = ExceptionGroup("eg", [exc_class(*exc_args)])
+
+    kwargs = _build_kwargs()
+    with pytest.raises(kopf.PermanentError):
+        await create_fn(**kwargs)
+
+    patch_obj = kwargs["patch"]
+    assert patch_obj.status["phase"] == "Failed"
+
+
+# ============================================================================
+# Mixed group: transient + permanent → still retries
+# ============================================================================
+
+@pytest.mark.asyncio
+@patch("app.controllers.ai_agent_config._validate", new_callable=AsyncMock)
+async def test_mixed_group_prefers_temporary(mock_validate):
+    """When a group contains both transient and permanent errors, retry."""
+    mock_validate.side_effect = ExceptionGroup(
+        "eg",
+        [ConnectionRefusedError("refused"), ValueError("bad config")],
+    )
+
+    kwargs = _build_kwargs()
+    with pytest.raises(kopf.TemporaryError):
+        await create_fn(**kwargs)
+
+
+# ============================================================================
+# Status fields are set correctly on failure
+# ============================================================================
+
+@pytest.mark.asyncio
+@patch("app.controllers.ai_agent_config._validate", new_callable=AsyncMock)
+async def test_status_fields_on_failure(mock_validate):
+    """Verify status conditions contain correct reason and message on failure."""
+    mock_validate.side_effect = ExceptionGroup(
+        "eg", [ValueError("bad url")]
+    )
+
+    kwargs = _build_kwargs()
+    with pytest.raises(kopf.PermanentError):
+        await create_fn(**kwargs)
+
+    patch_obj = kwargs["patch"]
+    condition = patch_obj.status["conditions"][0]
+    assert condition["type"] == "Ready"
+    assert condition["status"] == "False"
+    assert condition["reason"] == "ConfigurationFailed"
+    assert "bad url" in condition["message"]


### PR DESCRIPTION
## Issue #205 

### Problem

When an `AIAgentConfig` and its target MCP server are deployed together (e.g. via the same Helm chart), the kopf handler fires before the MCP pod is Ready. `client.get_tools()` raises a connection error and the handler was immediately marked `PermanentError`, leaving the CR stuck at `phase: Failed` with no self-healing.

```
rancher-ai-agent: ERROR Handler 'create_fn/spec' failed permanently:
                          Failed to load MCP tools: All connection attempts failed
```

### Solution

Classify exceptions into **transient** (connection / timeout) vs **permanent** (configuration errors) and apply exponential backoff for transient failures.

**Transient** — retried with exponential backoff:
- `ConnectionError` (covers `ConnectionRefusedError`, `ConnectionResetError`, …)
- `TimeoutError`
- `OSError` (socket-level errors)
- `httpx.ConnectError`, `httpx.ConnectTimeout`, `httpx.ReadTimeout`, `httpx.WriteTimeout`, `httpx.PoolTimeout`

**Permanent** — fails immediately:
- `ValueError`, `KeyError`, and other logic errors (malformed `mcpURL`, missing secret, etc.)

### Behaviour

| Retry # | Delay |
|---------|-------|
| 0 | 1 s |
| 1 | 2 s |
| 2 | 4 s |
| … | doubles each time |
| 9+ | capped at 300 s |
| 50 | promoted to `PermanentError` |

After 50 retries (~3.5 hours total), the transient error is promoted to `PermanentError` to avoid retrying indefinitely.