### PR TITLE
add libgcc to docker image

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -12,8 +12,8 @@ COPY --from=target / /target
 
 # Install python on both builder and target.
 RUN PY_ZYPP=$(echo ${PYTHON_VERSION} | tr -d '.') && \
-    zypper --non-interactive install --no-recommends python${PY_ZYPP} python${PY_ZYPP}-pip && \
-    zypper --non-interactive --installroot /target install --no-recommends python${PY_ZYPP} python${PY_ZYPP}-pip
+    zypper --non-interactive install --no-recommends python${PY_ZYPP} python${PY_ZYPP}-pip libgcc_s1 && \
+    zypper --non-interactive --installroot /target install --no-recommends python${PY_ZYPP} python${PY_ZYPP}-pip libgcc_s1
 
 # Create group and user 'ai-agent' (UID/GID 1000) with no home directory and no shell.
 RUN echo "ai-agent:x:${GID}:" >> /target/etc/group && \


### PR DESCRIPTION
### Summary

Fixes a runtime crash when starting the application by explicitly installing the `libgcc_s1` package.

### Cause

Upgrading the base image to `bci-micro:16.1` stripped down the default environment further than previous versions. Compiled binary wheels used by dependencies (specifically `pydantic_core` via FastAPI) require the GNU C compiler runtime library (`libgcc_s.so.1`) to execute, which was missing from the bare-minimum micro target filesystem.

### Changes

Updated the `Dockerfile` to explicitly include `libgcc_s1` in the `zypper` installation steps for both the builder and the target container layers.