### PR TITLE
Use internal Rancher url

### DIFF
--- a/app/routers/websocket.py
+++ b/app/routers/websocket.py
@@ -27,7 +27,7 @@ async def get_user_id_from_websocket(websocket: WebSocket) -> str:
     Retrieves the user ID from the Rancher API using the session token from the WebSocket cookies.
     """
     cookies = websocket.cookies
-    rancher_url = os.environ.get("RANCHER_URL","https://rancher.cattle-system.svc")
+    rancher_url = os.environ.get("RANCHER_URL","https://rancher.cattle-system")
     token = os.environ.get("RANCHER_API_TOKEN", cookies.get("R_SESS", ""))
 
     return await get_user_id(rancher_url, token)

--- a/app/services/agent/factory.py
+++ b/app/services/agent/factory.py
@@ -160,10 +160,8 @@ def create_mcp_client(agent_config: AgentConfig, websocket: WebSocket | None = N
     if agent_config.authentication == AuthenticationType.RANCHER:
         if websocket:
             cookies = websocket.cookies
-            rancher_url = os.environ.get("RANCHER_URL", "https://" + websocket.url.hostname)
             token = os.environ.get("RANCHER_API_TOKEN", cookies.get("R_SESS", ""))
         else:
-            rancher_url = os.environ.get("RANCHER_URL", "")
             token = os.environ.get("RANCHER_API_TOKEN", "")
         
         mcp_url = os.environ.get("MCP_URL", agent_config.mcp_url)
@@ -174,7 +172,6 @@ def create_mcp_client(agent_config: AgentConfig, websocket: WebSocket | None = N
                 mcp_url = "https://" + mcp_url
         headers = {
             "R_token": token,
-            "R_url": rancher_url
         }
     elif agent_config.authentication == AuthenticationType.BASIC:
         mcp_url = agent_config.mcp_url

--- a/app/services/auth.py
+++ b/app/services/auth.py
@@ -36,20 +36,11 @@ async def get_user_id_from_request(request: Request) -> str:
     """
     Retrieves the user ID from the Rancher API using the session token from the request cookies.
     """
-    rancher_url = os.environ.get("RANCHER_URL", "")
+    rancher_url = os.environ.get("RANCHER_URL", "https://rancher.cattle-system")
     token = request.cookies.get("R_SESS")
 
-    host = ""
     if not token:
         logging.warning("R_SESS cookie not found")
         return None
 
-    if rancher_url:
-        parsed = urlparse(rancher_url)
-        scheme = parsed.scheme or "https"
-        netloc = parsed.netloc
-        host = f"{scheme}://{netloc}"
-    else:
-        host = "https://rancher.cattle-system.svc"
-
-    return await get_user_id(host, token)
+    return await get_user_id(rancher_url, token)

--- a/tests/unit/services/agent/test_factory.py
+++ b/tests/unit/services/agent/test_factory.py
@@ -406,7 +406,6 @@ def test_create_mcp_client_rancher_auth_with_websocket(mock_mcp_client):
     call_args = mock_mcp_client.call_args[0][0]
     assert call_args["TestAgent"]["url"] == "https://mcp-service:8080"
     assert call_args["TestAgent"]["headers"]['R_token'] == 'test-token'
-    assert call_args["TestAgent"]["headers"]['R_url'] == 'https://rancher.example.com'
 
 
 @patch('app.services.agent.factory.MultiServerMCPClient')


### PR DESCRIPTION
Do not pass public Rancher URL in the `R_url` header.
Related to https://github.com/rancher/rancher-ai-mcp/pull/95/