### PR TITLE
fix: gracefully handle child agent and confirmation plan failures

### DIFF
--- a/app/services/agent/middleware/human_validation.py
+++ b/app/services/agent/middleware/human_validation.py
@@ -58,7 +58,7 @@ def human_validation_middleware(
             # Return a ToolMessage (not raise) so the tool_use block keeps its matching
             # tool_result. Otherwise the checkpointed history has a dangling tool_use and
             # the next model call fails (e.g. Bedrock ValidationException).
-            logging.error(f"Failed to build confirmation plan for tool '{tool_call['name']}': {e}")
+            logging.exception(f"Failed to build confirmation plan for tool '{tool_call['name']}': {e}")
             return ToolMessage(
                 content=f"Could not prepare confirmation for tool '{tool_call['name']}': {e}",
                 name=tool_call["name"],

--- a/app/services/agent/middleware/human_validation.py
+++ b/app/services/agent/middleware/human_validation.py
@@ -52,7 +52,19 @@ def human_validation_middleware(
         }
 
         human_validation_tools = getattr(agent_config, "human_validation_tools", [])
-        interrupt_message = await _should_interrupt(human_validation_tools, tool_call, planning_tools_by_name)
+        try:
+            interrupt_message = await _should_interrupt(human_validation_tools, tool_call, planning_tools_by_name)
+        except Exception as e:
+            # Return a ToolMessage (not raise) so the tool_use block keeps its matching
+            # tool_result. Otherwise the checkpointed history has a dangling tool_use and
+            # the next model call fails (e.g. Bedrock ValidationException).
+            logging.error(f"Failed to build confirmation plan for tool '{tool_call['name']}': {e}")
+            return ToolMessage(
+                content=f"Could not prepare confirmation for tool '{tool_call['name']}': {e}",
+                name=tool_call["name"],
+                tool_call_id=tool_call["id"],
+                additional_kwargs=additional_kwargs,
+            )
 
         if interrupt_message:
             logging.debug(f"Confirmation interrupt triggered for tool '{tool_call['name']}'")
@@ -144,7 +156,9 @@ async def _should_interrupt(
             try:
                 safe_response = json.dumps(json.loads(plan_response))
             except (json.JSONDecodeError, TypeError):
-                safe_response = json.dumps(plan_response)
+                raise Exception(
+                    f"Invalid plan response for tool '{tool_call['name']}': {plan_response}"
+                )
             return f"<confirmation-response>{safe_response}</confirmation-response>"
     return ""
 

--- a/app/services/agent/supervisor.py
+++ b/app/services/agent/supervisor.py
@@ -311,7 +311,7 @@ def _create_agent_tool(child_agent: ChildAgent, call_counter: _AgentCallCounter)
                 # swallow it and break LangGraph's interrupt / control-flow mechanism.
                 raise
             except Exception as e:
-                logging.error(f"Child agent '{agent_name}' failed during resume: {e}")
+                logging.exception(f"Child agent '{agent_name}' failed during resume: {e}")
                 return _build_error_result(agent_name, e, interrupt_ui_tools)
             # If the user declined, return the cancel message so the supervisor's
             # cancel_check_middleware ends the graph.
@@ -336,7 +336,7 @@ def _create_agent_tool(child_agent: ChildAgent, call_counter: _AgentCallCounter)
                 # supervisor runtime can handle any interrupt raised by the child.
                 raise
             except Exception as e:
-                logging.error(f"Child agent '{agent_name}' failed: {e}")
+                logging.exception(f"Child agent '{agent_name}' failed: {e}")
                 _dispatch_subagent_event("processing-subagent-end", agent_name, query)
                 return _build_error_result(agent_name, e, interrupt_ui_tools)
             _dispatch_subagent_event("processing-subagent-end", agent_name, query)

--- a/app/services/agent/supervisor.py
+++ b/app/services/agent/supervisor.py
@@ -20,6 +20,7 @@ from langgraph.graph.state import Any, CompiledStateGraph, Checkpointer
 from langchain.agents.middleware import SummarizationMiddleware
 from langchain.messages import  HumanMessage, ToolMessage
 import langgraph.types
+from langgraph.errors import GraphBubbleUp
 from langgraph.types import Command
 from langchain_core.callbacks.manager import dispatch_custom_event
 from dataclasses import dataclass
@@ -181,6 +182,24 @@ def _extract_last_message(result: dict) -> str:
     return "No response from agent."
 
 
+def _build_error_result(agent_name: str, exc: Exception, ui_tools: list[dict]) -> tuple[str, dict]:
+    """Build the ``(content, metadata)`` tuple returned when a child agent invocation fails.
+
+    Surfaces the failure reason to the supervisor LLM as tool content instead of
+    letting the exception crash the supervisor run.
+    """
+    return (
+        f"The '{agent_name}' agent failed: {exc}",
+        {
+            "mcp_response": None,
+            "mcp_data": None,
+            "interrupt_info": None,
+            "created_at": None,
+            "ui_tools": ui_tools,
+        },
+    )
+
+
 def _extract_tool_metadata(result: dict) -> dict:
     """Extract mcp_response, mcp_data, interrupt_info, and created_at from result messages.
 
@@ -283,7 +302,17 @@ def _create_agent_tool(child_agent: ChildAgent, call_counter: _AgentCallCounter)
                 interrupt_ui_tools = interrupt_value.get("ui_tools", [])
 
             resume_value = langgraph.types.interrupt(interrupt_value)
-            result = await child_agent.agent.ainvoke(Command(resume=resume_value), config=child_config)
+            try:
+                result = await child_agent.agent.ainvoke(Command(resume=resume_value), config=child_config)
+            except GraphBubbleUp:
+                # GraphBubbleUp is a LangGraph internal signal (e.g. a new interrupt) that
+                # must propagate up through the call stack to be handled by the supervisor
+                # graph runtime.  Catching it in the broad `except Exception` below would
+                # swallow it and break LangGraph's interrupt / control-flow mechanism.
+                raise
+            except Exception as e:
+                logging.error(f"Child agent '{agent_name}' failed during resume: {e}")
+                return _build_error_result(agent_name, e, interrupt_ui_tools)
             # If the user declined, return the cancel message so the supervisor's
             # cancel_check_middleware ends the graph.
             for msg in reversed(result.get("messages", [])):
@@ -297,10 +326,19 @@ def _create_agent_tool(child_agent: ChildAgent, call_counter: _AgentCallCounter)
             child_config["tags"] = ["no-stream"]
             
             _dispatch_subagent_event("processing-subagent-start", agent_name, query)
-            result = await child_agent.agent.ainvoke(
-                {"messages": [HumanMessage(content=query)]},
-                config=child_config,
-            )
+            try:
+                result = await child_agent.agent.ainvoke(
+                    {"messages": [HumanMessage(content=query)]},
+                    config=child_config,
+                )
+            except GraphBubbleUp:
+                # Same as above: let LangGraph's internal signal propagate so the
+                # supervisor runtime can handle any interrupt raised by the child.
+                raise
+            except Exception as e:
+                logging.error(f"Child agent '{agent_name}' failed: {e}")
+                _dispatch_subagent_event("processing-subagent-end", agent_name, query)
+                return _build_error_result(agent_name, e, interrupt_ui_tools)
             _dispatch_subagent_event("processing-subagent-end", agent_name, query)
 
         metadata = _extract_tool_metadata(result)

--- a/tests/unit/services/agent/middleware/test_human_validation.py
+++ b/tests/unit/services/agent/middleware/test_human_validation.py
@@ -86,14 +86,12 @@ async def test_should_interrupt_handles_non_json_response():
     plan_tool = AsyncMock()
     plan_tool.ainvoke.return_value = "plain text plan"
 
-    result = await _should_interrupt(
-        human_validation_tools=["applyResource"],
-        tool_call={"name": "applyResource", "args": {}},
-        planning_tools_by_name={"applyResourcePlan": plan_tool},
-    )
-
-    inner = result.removeprefix("<confirmation-response>").removesuffix("</confirmation-response>")
-    assert json.loads(inner) == "plain text plan"
+    with pytest.raises(Exception, match="Invalid plan response for tool 'applyResource'"):
+        await _should_interrupt(
+            human_validation_tools=["applyResource"],
+            tool_call={"name": "applyResource", "args": {}},
+            planning_tools_by_name={"applyResourcePlan": plan_tool},
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/services/agent/test_supervisor_agent.py
+++ b/tests/unit/services/agent/test_supervisor_agent.py
@@ -405,6 +405,141 @@ async def test_invoke_normal_child_interrupts_during_invocation(child_agent, moc
 
 
 # ============================================================================
+# GraphBubbleUp propagation Tests
+# ============================================================================
+
+@pytest.mark.asyncio
+async def test_graph_bubble_up_propagates_during_normal_invocation(child_agent, mock_compiled_graph):
+    """GraphBubbleUp raised by the child during a normal (no pending interrupt) invocation
+    must propagate out of _invoke rather than being caught as a generic error."""
+    from langgraph.errors import GraphBubbleUp
+
+    mock_state = MagicMock()
+    mock_state.interrupts = ()
+    mock_compiled_graph.aget_state.return_value = mock_state
+    mock_compiled_graph.ainvoke.side_effect = GraphBubbleUp("internal signal")
+
+    tool = _create_agent_tool(child_agent, _AgentCallCounter())
+
+    with patch("app.services.agent.supervisor.ensure_config", return_value={
+        "configurable": {"thread_id": "t1"}
+    }):
+        with pytest.raises(GraphBubbleUp):
+            await tool.ainvoke({"query": "trigger bubble up"})
+
+
+@pytest.mark.asyncio
+async def test_graph_bubble_up_not_treated_as_error_during_normal_invocation(child_agent, mock_compiled_graph):
+    """GraphBubbleUp must not cause _build_error_result to be returned; the exception
+    must escape so the supervisor graph runtime can handle it."""
+    from langgraph.errors import GraphBubbleUp
+
+    mock_state = MagicMock()
+    mock_state.interrupts = ()
+    mock_compiled_graph.aget_state.return_value = mock_state
+    mock_compiled_graph.ainvoke.side_effect = GraphBubbleUp("internal signal")
+
+    tool = _create_agent_tool(child_agent, _AgentCallCounter())
+
+    with patch("app.services.agent.supervisor.ensure_config", return_value={
+        "configurable": {"thread_id": "t1"}
+    }):
+        try:
+            await tool.ainvoke({"query": "trigger bubble up"})
+        except GraphBubbleUp:
+            pass  # expected
+        except Exception as e:
+            pytest.fail(f"GraphBubbleUp was swallowed and replaced by: {type(e).__name__}: {e}")
+
+
+@pytest.mark.asyncio
+async def test_graph_bubble_up_propagates_during_resume(child_agent, mock_compiled_graph):
+    """GraphBubbleUp raised by the child during a resume invocation must propagate
+    out of _invoke rather than being caught as a generic error."""
+    from langgraph.errors import GraphBubbleUp
+
+    mock_interrupt = MagicMock()
+    mock_interrupt.value = "confirm?"
+    mock_state_with_interrupt = MagicMock()
+    mock_state_with_interrupt.interrupts = (mock_interrupt,)
+    mock_compiled_graph.aget_state.return_value = mock_state_with_interrupt
+    mock_compiled_graph.ainvoke.side_effect = GraphBubbleUp("internal signal on resume")
+
+    tool = _create_agent_tool(child_agent, _AgentCallCounter())
+
+    with patch("app.services.agent.supervisor.ensure_config", return_value={
+        "configurable": {"thread_id": "t1"}
+    }), patch("app.services.agent.supervisor.langgraph.types.interrupt", return_value="yes"):
+        with pytest.raises(GraphBubbleUp):
+            await tool.ainvoke({"query": "resume action"})
+
+
+@pytest.mark.asyncio
+async def test_graph_bubble_up_not_treated_as_error_during_resume(child_agent, mock_compiled_graph):
+    """GraphBubbleUp during resume must not produce an error result tuple; it must escape."""
+    from langgraph.errors import GraphBubbleUp
+
+    mock_interrupt = MagicMock()
+    mock_interrupt.value = "confirm?"
+    mock_state_with_interrupt = MagicMock()
+    mock_state_with_interrupt.interrupts = (mock_interrupt,)
+    mock_compiled_graph.aget_state.return_value = mock_state_with_interrupt
+    mock_compiled_graph.ainvoke.side_effect = GraphBubbleUp("internal signal on resume")
+
+    tool = _create_agent_tool(child_agent, _AgentCallCounter())
+
+    with patch("app.services.agent.supervisor.ensure_config", return_value={
+        "configurable": {"thread_id": "t1"}
+    }), patch("app.services.agent.supervisor.langgraph.types.interrupt", return_value="yes"):
+        try:
+            await tool.ainvoke({"query": "resume action"})
+        except GraphBubbleUp:
+            pass  # expected
+        except Exception as e:
+            pytest.fail(f"GraphBubbleUp was swallowed and replaced by: {type(e).__name__}: {e}")
+
+
+@pytest.mark.asyncio
+async def test_generic_exception_still_returns_error_result_during_normal_invocation(child_agent, mock_compiled_graph):
+    """Non-GraphBubbleUp exceptions during normal invocation are caught and returned
+    as an error result tuple, not re-raised."""
+    mock_state = MagicMock()
+    mock_state.interrupts = ()
+    mock_compiled_graph.aget_state.return_value = mock_state
+    mock_compiled_graph.ainvoke.side_effect = RuntimeError("mcp connection refused")
+
+    tool = _create_agent_tool(child_agent, _AgentCallCounter())
+
+    with patch("app.services.agent.supervisor.ensure_config", return_value={
+        "configurable": {"thread_id": "t1"}
+    }):
+        result = await tool.ainvoke({"query": "do something"})
+
+    assert "failed" in result.lower() or "mcp connection refused" in result.lower()
+
+
+@pytest.mark.asyncio
+async def test_generic_exception_still_returns_error_result_during_resume(child_agent, mock_compiled_graph):
+    """Non-GraphBubbleUp exceptions during resume are caught and returned as an error
+    result tuple, not re-raised."""
+    mock_interrupt = MagicMock()
+    mock_interrupt.value = "confirm?"
+    mock_state_with_interrupt = MagicMock()
+    mock_state_with_interrupt.interrupts = (mock_interrupt,)
+    mock_compiled_graph.aget_state.return_value = mock_state_with_interrupt
+    mock_compiled_graph.ainvoke.side_effect = RuntimeError("timeout during resume")
+
+    tool = _create_agent_tool(child_agent, _AgentCallCounter())
+
+    with patch("app.services.agent.supervisor.ensure_config", return_value={
+        "configurable": {"thread_id": "t1"}
+    }), patch("app.services.agent.supervisor.langgraph.types.interrupt", return_value="yes"):
+        result = await tool.ainvoke({"query": "resume action"})
+
+    assert "timeout during resume" in result.lower()
+
+
+# ============================================================================
 # _AgentCallCounter Tests
 # ============================================================================
 


### PR DESCRIPTION
## Issue https://github.com/rancher/rancher-ai-agent/issues/289

## Problem

When a child agent (invoked as a tool by the supervisor) raised an exception, the error propagated unhandled and crashed the entire supervisor run. When building a human-validation confirmation plan returned an invalid/non-JSON response, the error was silently swallowed and replaced with an unconverted raw string — but no `ToolMessage` was returned, leaving a dangling `tool_use` block in the checkpoint history. On the next LLM call (e.g. Bedrock), this caused a `ValidationException`. 

## Solution

Wrap child agent `ainvoke` calls (both initial and resume) in try/except. On failure, surface the error back to the supervisor as tool content via _build_error_result, letting the supervisor LLM decide how to proceed rather than crashing. Re-raise `GraphBubbleUp` explicitly so LangGraph's internal interrupt/control-flow signals are never swallowed. In `human_validation_middleware`, catch exceptions from `_should_interrupt` and return a `ToolMessage` with the error instead of raising. Ensuring the tool_use/tool_result pair in the message history always stays balanced.