### PR TITLE
Support per-agent LLM model override

### DIFF
--- a/app/services/agent/child.py
+++ b/app/services/agent/child.py
@@ -22,6 +22,7 @@ from .middleware import (
     human_validation_middleware,
     cancel_human_validation_middleware,
 )
+from ..llm import get_llm_with_model
 
 INTERRUPT_PREVIOUS_TOOL_FAILED_MESSAGE = "tool execution cancelled because previous tool call failed"
 
@@ -37,7 +38,6 @@ CHILD_TOOL_USE_INSTRUCTIONS = """
 def create_child_agent(
     llm: BaseChatModel,
     tools: list[BaseTool],
-    system_prompt: str,
     checkpointer: Checkpointer,
     agent_config: AgentConfig,
 ) -> CompiledStateGraph:
@@ -61,10 +61,13 @@ def create_child_agent(
         SummarizationMiddleware(model=llm, trigger=[("messages", 30), ("tokens", 30000)], keep=("messages", 15)),
     ]
 
+    if agent_config.llm_model_enabled and agent_config.llm_model:
+        llm = get_llm_with_model(agent_config.llm_model)
+
     return create_agent(
         llm,
         tools=execution_tools,
-        system_prompt=system_prompt + CHILD_TOOL_USE_INSTRUCTIONS,
+        system_prompt=agent_config.system_prompt + CHILD_TOOL_USE_INSTRUCTIONS,
         checkpointer=checkpointer,
         middleware=middleware,
     )

--- a/app/services/agent/factory.py
+++ b/app/services/agent/factory.py
@@ -47,7 +47,7 @@ async def build_agent(llm: BaseLanguageModel, websocket: WebSocket) -> tuple[Com
     if len(agent_configs) == 1:
         agent_cfg = agent_configs[0]
         tools = await _load_mcp_tools(agent_cfg, websocket)
-        graph = create_child_agent(llm, tools, agent_cfg.system_prompt, checkpointer, agent_cfg)
+        graph = create_child_agent(llm, tools, checkpointer, agent_cfg)
         return graph, [{"name": agent_cfg.name, "status": "active"}]
 
     # Multi-agent setup
@@ -92,14 +92,14 @@ async def _build_child_agents(
             tools = await _load_mcp_tools(agent_cfg, websocket)
             child_agents.append(ChildAgent(
                 config=agent_cfg,
-                agent=create_child_agent(llm, tools, agent_cfg.system_prompt, checkpointer, agent_cfg),
+                agent=create_child_agent(llm, tools, checkpointer, agent_cfg),
             ))
             agents_metadata.append({"name": agent_cfg.name, "status": "active"})
         except NeedsOauth2 as e:
             logging.debug(f"OAuth2 authentication required for agent '{agent_cfg.name}': {e}")
             child_agents.append(ChildAgent(
                 config=agent_cfg,
-                agent=create_child_agent(llm, [], agent_cfg.system_prompt, checkpointer, agent_cfg),
+                agent=create_child_agent(llm, [], checkpointer, agent_cfg),
                 needs_oauth2=True
             ))
             agents_metadata.append({"name": agent_cfg.name, "status": "active", "description": "needs_oauth2"})
@@ -134,7 +134,7 @@ async def reload_agent_tools(
     """
     checkpointer = websocket.app.memory_manager.get_checkpointer()
     tools = await _load_mcp_tools(agent_cfg, websocket)
-    return create_child_agent(llm, tools, agent_cfg.system_prompt, checkpointer, agent_cfg)
+    return create_child_agent(llm, tools, checkpointer, agent_cfg)
 
 
 async def _load_mcp_tools(agent_cfg: AgentConfig, websocket: WebSocket) -> list:

--- a/app/services/agent/loader.py
+++ b/app/services/agent/loader.py
@@ -175,6 +175,8 @@ class AgentConfig(BaseModel):
     ca_bundle_ref: Optional[CABundleRef] = None
     toolset: Optional[str] = None
     human_validation_tools: list[str] = []
+    llm_model: Optional[str] = None
+    llm_model_enabled: bool = False
     ready: bool = False
 
 
@@ -320,6 +322,8 @@ def _crd_to_agent_config(crd_obj: dict) -> AgentConfig:
         ca_bundle_ref=CABundleRef(**spec["caBundleRef"]) if spec.get("caBundleRef") else None,
         toolset=spec.get("toolSet", None),
         human_validation_tools=human_validation_tools,
+        llm_model=spec.get("llmModel", None),
+        llm_model_enabled=spec.get("llmModelEnabled", False),
         ready=status.get("phase", "Failed") == "Ready"
     )
 

--- a/app/services/llm.py
+++ b/app/services/llm.py
@@ -5,6 +5,7 @@ from langchain_ollama import ChatOllama
 from langchain_google_genai import ChatGoogleGenerativeAI
 from langchain_openai import ChatOpenAI
 from langchain_core.language_models.llms import BaseLanguageModel
+from langchain_core.language_models.chat_models import BaseChatModel
 from langchain_aws import ChatBedrockConverse
 
 class LLMManager:
@@ -33,12 +34,15 @@ class LLMManager:
             logging.info(f"Using model: {cls._instance}")
         return cls._instance
 
-def get_llm() -> BaseLanguageModel:
+def get_llm(model_override: str | None = None) -> BaseChatModel:
     """
     Selects and returns a language model instance based on environment variables.
     - If the active LLM or the model is not configured, it raises a ValueError.
     - If LLM mocking is enabled, it configures the connections to the mock server.
     
+    Args:
+        model_override: If provided, use this model name instead of the one from environment variables.
+
     Returns:
         An instance of a language model.
         
@@ -47,7 +51,7 @@ def get_llm() -> BaseLanguageModel:
     """
 
     activeLlm = get_active_llm()
-    model = get_llm_model(activeLlm)
+    model = model_override if model_override else get_llm_model(activeLlm)
     
     llm_mock_enabled = os.environ.get("LLM_MOCK_ENABLED", "false").lower() == "true"
     llm_mock_url = os.environ.get("LLM_MOCK_URL", "")
@@ -89,6 +93,13 @@ def get_llm() -> BaseLanguageModel:
         generic_openai_api_key = os.environ.get("GENERIC_OPENAI_API_KEY")
 
         return ChatOpenAI(model=model, base_url=generic_openai_url, api_key=generic_openai_api_key)
+
+    raise ValueError(f"Unsupported LLM provider: {activeLlm}")
+
+
+def get_llm_with_model(model: str) -> BaseChatModel:
+    """Create an LLM instance using the active provider but with a specific model override."""
+    return get_llm(model_override=model)
 
 
 def get_active_llm() -> str:

--- a/chart/agent/templates/crds/ai.cattle.io_aiagentconfigs.yaml
+++ b/chart/agent/templates/crds/ai.cattle.io_aiagentconfigs.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.1
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: aiagentconfigs.ai.cattle.io
 spec:
   group: ai.cattle.io
@@ -98,6 +98,14 @@ spec:
                 items:
                   type: string
                 type: array
+              llmModel:
+                description: LLMModel specifies the large language model to use for
+                  this agent
+                type: string
+              llmModelEnabled:
+                description: LLMModelEnabled indicates if a custom LLM model is enabled
+                  for this agent
+                type: boolean
               mcpURL:
                 description: MCPURL is the Model Context Protocol server URL
                 type: string

--- a/crd-generation/api/v1alpha1/aiagentconfig_types.go
+++ b/crd-generation/api/v1alpha1/aiagentconfig_types.go
@@ -53,6 +53,14 @@ type AIAgentConfigSpec struct {
 	// The CA is scoped to this agent's connection only.
 	// +optional
 	CABundleRef *SecretKeyRef `json:"caBundleRef,omitempty"`
+
+	// LLMModel specifies the large language model to use for this agent
+	// +optional
+	LLMModel string `json:"llmModel,omitempty"`
+
+	// LLMModelEnabled indicates if a custom LLM model is enabled for this agent
+	// +optional
+	LLMModelEnabled bool `json:"llmModelEnabled,omitempty"`
 }
 
 // SecretKeyRef identifies a key within a Kubernetes secret.

--- a/tests/unit/services/agent/test_child_agent.py
+++ b/tests/unit/services/agent/test_child_agent.py
@@ -38,6 +38,8 @@ def agent_config():
     """Minimal AgentConfig mock."""
     config = MagicMock()
     config.human_validation_tools = []
+    config.llm_model_enabled = False
+    config.llm_model = None
     return config
 
 
@@ -60,7 +62,6 @@ def test_create_child_agent_excludes_plan_tools_from_execution(mock_create_agent
     create_child_agent(
         llm=mock_llm,
         tools=tools,
-        system_prompt="test",
         checkpointer=mock_checkpointer,
         agent_config=agent_config,
     )
@@ -87,7 +88,6 @@ def test_create_child_agent_registers_expected_middleware(mock_create_agent, moc
     create_child_agent(
         llm=mock_llm,
         tools=tools,
-        system_prompt="test",
         checkpointer=mock_checkpointer,
         agent_config=agent_config,
     )
@@ -113,10 +113,11 @@ def test_create_child_agent_appends_tool_use_instructions_to_prompt(mock_create_
 
     tools = [_make_langchain_tool("testTool")]
 
+    agent_config.system_prompt = "Base prompt."
+
     create_child_agent(
         llm=mock_llm,
         tools=tools,
-        system_prompt="Base prompt.",
         checkpointer=mock_checkpointer,
         agent_config=agent_config,
     )
@@ -126,3 +127,74 @@ def test_create_child_agent_appends_tool_use_instructions_to_prompt(mock_create_
 
     assert system_prompt.startswith("Base prompt.")
     assert CHILD_TOOL_USE_INSTRUCTIONS in system_prompt
+
+
+@patch("app.services.agent.child.get_llm_with_model")
+@patch("app.services.agent.child.create_agent")
+def test_create_child_agent_uses_custom_llm_when_enabled(mock_create_agent, mock_get_llm_with_model, mock_llm, mock_checkpointer, agent_config):
+    """Verify create_child_agent uses per-agent LLM when llm_model_enabled is True."""
+    mock_create_agent.return_value = MagicMock()
+    custom_llm = MagicMock()
+    mock_get_llm_with_model.return_value = custom_llm
+
+    agent_config.llm_model_enabled = True
+    agent_config.llm_model = "gemini-2.0-flash"
+
+    tools = [_make_langchain_tool("testTool")]
+
+    create_child_agent(
+        llm=mock_llm,
+        tools=tools,
+        checkpointer=mock_checkpointer,
+        agent_config=agent_config,
+    )
+
+    mock_get_llm_with_model.assert_called_once_with("gemini-2.0-flash")
+    call_args = mock_create_agent.call_args
+    assert call_args[0][0] == custom_llm
+
+
+@patch("app.services.agent.child.get_llm_with_model")
+@patch("app.services.agent.child.create_agent")
+def test_create_child_agent_uses_default_llm_when_override_disabled(mock_create_agent, mock_get_llm_with_model, mock_llm, mock_checkpointer, agent_config):
+    """Verify create_child_agent uses the default LLM when llm_model_enabled is False."""
+    mock_create_agent.return_value = MagicMock()
+
+    agent_config.llm_model_enabled = False
+    agent_config.llm_model = "gemini-2.0-flash"
+
+    tools = [_make_langchain_tool("testTool")]
+
+    create_child_agent(
+        llm=mock_llm,
+        tools=tools,
+        checkpointer=mock_checkpointer,
+        agent_config=agent_config,
+    )
+
+    mock_get_llm_with_model.assert_not_called()
+    call_args = mock_create_agent.call_args
+    assert call_args[0][0] == mock_llm
+
+
+@patch("app.services.agent.child.get_llm_with_model")
+@patch("app.services.agent.child.create_agent")
+def test_create_child_agent_uses_default_llm_when_model_not_set(mock_create_agent, mock_get_llm_with_model, mock_llm, mock_checkpointer, agent_config):
+    """Verify create_child_agent uses the default LLM when llm_model is None."""
+    mock_create_agent.return_value = MagicMock()
+
+    agent_config.llm_model_enabled = True
+    agent_config.llm_model = None
+
+    tools = [_make_langchain_tool("testTool")]
+
+    create_child_agent(
+        llm=mock_llm,
+        tools=tools,
+        checkpointer=mock_checkpointer,
+        agent_config=agent_config,
+    )
+
+    mock_get_llm_with_model.assert_not_called()
+    call_args = mock_create_agent.call_args
+    assert call_args[0][0] == mock_llm

--- a/tests/unit/services/agent/test_factory.py
+++ b/tests/unit/services/agent/test_factory.py
@@ -54,7 +54,7 @@ async def test_create_agent_single_agent(mock_create_child, mock_load_tools, moc
     assert result[1] == [{"name": "RancherAgent", "status": "active"}]
     mock_load_tools.assert_called_once_with(mock_agent_config, mock_websocket)
     mock_create_child.assert_called_once_with(
-        mock_llm, mock_tools, "Test prompt", mock_checkpointer, mock_agent_config
+        mock_llm, mock_tools, mock_checkpointer, mock_agent_config
     )
 
 

--- a/tests/unit/services/test_llm.py
+++ b/tests/unit/services/test_llm.py
@@ -122,3 +122,43 @@ def test_get_llm_openai_with_custom_url(mock_openai):
         mock_openai.assert_called_once_with(model="gpt-4", base_url="http://custom-openai:8000")
         assert llm == mock_openai.return_value
 
+
+@patch('app.services.llm.ChatOpenAI')
+def test_get_llm_with_model_override(mock_openai):
+    """Test that model_override overrides the env-configured model."""
+    with patch.dict(os.environ, {
+        "OPENAI_MODEL": "gpt-4",
+        "ACTIVE_LLM": "openai",
+        "OPENAI_API_KEY": "fake-key",
+    }, clear=True):
+        llm = get_llm(model_override="gpt-4o")
+        mock_openai.assert_called_once_with(model="gpt-4o")
+        assert llm == mock_openai.return_value
+
+
+@patch('app.services.llm.ChatGoogleGenerativeAI')
+def test_get_llm_with_model_override_gemini(mock_chat_gemini):
+    """Test that model_override works with Gemini provider."""
+    with patch.dict(os.environ, {
+        "GEMINI_MODEL": "gemini-pro",
+        "ACTIVE_LLM": "gemini",
+        "GOOGLE_API_KEY": "fake-key",
+    }, clear=True):
+        llm = get_llm(model_override="gemini-2.0-flash")
+        mock_chat_gemini.assert_called_once_with(model="gemini-2.0-flash")
+        assert llm == mock_chat_gemini.return_value
+
+
+@patch('app.services.llm.ChatOpenAI')
+def test_get_llm_with_model_uses_get_llm(mock_openai):
+    """Test that get_llm_with_model delegates to get_llm with the model override."""
+    from app.services.llm import get_llm_with_model
+    with patch.dict(os.environ, {
+        "OPENAI_MODEL": "gpt-4",
+        "ACTIVE_LLM": "openai",
+        "OPENAI_API_KEY": "fake-key",
+    }, clear=True):
+        llm = get_llm_with_model("gpt-4o-mini")
+        mock_openai.assert_called_once_with(model="gpt-4o-mini")
+        assert llm == mock_openai.return_value
+


### PR DESCRIPTION
## Issue https://github.com/rancher/rancher-ai-agent/issues/170

## Problem

All agents shared the same LLM model, making it impossible to assign a different model to specific agents even when using the same provider (e.g. gemini-pro for most agents but gemini-2.5-flash for one).

## Solution

Added two new fields to `AIAgentConfig`: `llmModel` and `llmModelEnabled`. When both are set, the agent uses that model instead of the global default, while keeping the same provider and its configuration