### PR TITLE
Add list and watch secret permissions to MCP

### DIFF
--- a/chart/agent/templates/rbac/mcp-sa.yaml
+++ b/chart/agent/templates/rbac/mcp-sa.yaml
@@ -40,7 +40,7 @@ rules:
   resourceNames: ["cattle-mcp-tls", "cattle-mcp-ca"]
 - apiGroups: [""]
   resources: ["secrets"]
-  verbs: ["create"]
+  verbs: ["create", "list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding


### PR DESCRIPTION
## Problem

[dynamiclistener](https://github.com/rancher/dynamiclistener) needs list and watch permission on secrets in new versions.

```
time="2026-07-23T09:31:35Z" level=warning msg="Skipping save of TLS secret for cattle-ai-agent-system/cattle-mcp-tls due to missing certificate data"
time="2026-07-23T09:31:35Z" level=info msg="Active TLS secret cattle-ai-agent-system/cattle-mcp-tls (ver=) (count -1): map[]"
E0723 09:31:35.316142       1 reflector.go:227] "Failed to watch" err="failed to list *v1.Secret: secrets \"cattle-mcp-tls\" is forbidden: User \"system:serviceaccount:cattle-ai-agent-system:mcp-cert-rotator-sa\" cannot list resource \"secrets\" in API group \"\" in the namespace \"cattle-ai-agent-system\"" logger="UnhandledError" reflector="pkg/mod/k8s.io/client-go@v0.36.2/tools/cache/reflector.go:343" type="*v1.Secret"
```

## Solution

Grant watch and list permissions on secrets to the `cert-rotator-role`