### PR TITLE
Fix chat when using custom CA with insecureSkipTls=false

### DIFF
--- a/app/routers/chat.py
+++ b/app/routers/chat.py
@@ -2,7 +2,7 @@ import logging
 from fastapi import APIRouter, HTTPException, Request, status
 from fastapi.responses import Response, JSONResponse
 
-from ..services.auth import get_user_id_from_request
+from ..services.auth import get_user_id_from_token
 
 router = APIRouter(prefix="/v1/api", tags=["chats"])
 
@@ -17,7 +17,7 @@ async def get_chats(request: Request, sort: str = "createdAt:desc"):
     """
 
     try:
-        user_id = await get_user_id_from_request(request)
+        user_id = await get_user_id_from_token(request.cookies)
         
         if not user_id:
             raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Unauthorized")
@@ -52,7 +52,7 @@ async def delete_chats(request: Request) -> JSONResponse:
     """
 
     try:
-        user_id = await get_user_id_from_request(request)
+        user_id = await get_user_id_from_token(request.cookies)
         
         if not user_id:
             raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Unauthorized")
@@ -84,7 +84,7 @@ async def get_chat(request: Request, chat_id: str) -> JSONResponse:
     """
 
     try:
-        user_id = await get_user_id_from_request(request)
+        user_id = await get_user_id_from_token(request.cookies)
         
         if not user_id:
             raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Unauthorized")
@@ -125,7 +125,7 @@ async def update_chat(request: Request, chat_id: str, chat_data: dict) -> JSONRe
     """
 
     try:
-        user_id = await get_user_id_from_request(request)
+        user_id = await get_user_id_from_token(request.cookies)
         
         if not user_id:
             raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Unauthorized")
@@ -179,7 +179,7 @@ async def delete_chat(request: Request, chat_id: str) -> JSONResponse:
     """
 
     try:
-        user_id = await get_user_id_from_request(request)
+        user_id = await get_user_id_from_token(request.cookies)
         
         if not user_id:
             raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Unauthorized")
@@ -215,7 +215,7 @@ async def get_chat_messages(request: Request, chat_id: str) -> JSONResponse:
     """
 
     try:        
-        user_id = await get_user_id_from_request(request)
+        user_id = await get_user_id_from_token(request.cookies)
         
         if not user_id:
             raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Unauthorized")

--- a/app/routers/configuration.py
+++ b/app/routers/configuration.py
@@ -9,7 +9,7 @@ from kubernetes import client, config as k8s_config
 from kubernetes.client.rest import ApiException
 
 from ..services.llm import LLMManager
-from ..services.auth import get_user_id_from_request
+from ..services.auth import get_user_id_from_token
 
 router = APIRouter(prefix="/v1/api", tags=["configuration"])
 
@@ -139,7 +139,7 @@ async def get_models(request: Request, llm_name: str):
     For bedrock: requires 'region' and 'bearer_token'
     """
     try:
-        user_id = await get_user_id_from_request(request)
+        user_id = await get_user_id_from_token(request.cookies)
         
         if not user_id:
             raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Unauthorized")
@@ -264,7 +264,7 @@ async def get_settings(request: Request):
     Endpoint to retrieve current agent settings.
     """
     try:
-        user_id = await get_user_id_from_request(request)
+        user_id = await get_user_id_from_token(request.cookies)
         
         if not user_id:
             raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Unauthorized")
@@ -294,7 +294,7 @@ async def update_settings(settings: SettingsUpdate, request: Request):
     Requires permission to patch secrets in the agent namespace.
     """
     try:
-        user_id = await get_user_id_from_request(request)
+        user_id = await get_user_id_from_token(request.cookies)
 
         if not user_id:
             raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Unauthorized")

--- a/app/routers/llm.py
+++ b/app/routers/llm.py
@@ -4,7 +4,7 @@ from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 from langchain_core.language_models.llms import BaseLanguageModel
 
-from ..services.auth import get_user_id_from_request
+from ..services.auth import get_user_id_from_token
 from ..dependencies import get_llm
 from ..services.ui_tools.selector import create_ui_tools_selector
 
@@ -45,7 +45,7 @@ async def complete_ui_tools(
     """
 
     try:
-        user_id = await get_user_id_from_request(request)
+        user_id = await get_user_id_from_token(request.cookies)
         
         if not user_id:
             raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Unauthorized")

--- a/app/routers/oauth2.py
+++ b/app/routers/oauth2.py
@@ -8,7 +8,7 @@ from fastapi.responses import HTMLResponse, JSONResponse
 from fastapi import HTTPException, status
 from pydantic import BaseModel, HttpUrl
 from urllib.parse import urlparse
-from ..services.auth import get_user_id_from_request
+from ..services.auth import get_user_id_from_token
 from ..services.oauth2.client import OAuthClientManager, get_tls_verify
 from ..services.oauth2.discovery import discover_metadata_endpoint
 from ..services.agent.loader import AgentConfig, AuthenticationType, load_agent_configs
@@ -216,7 +216,7 @@ async def get_metadata(mcpUrl: str, request: Request):
 
     Returns discovered metadata (or `null` if discovery fails).
     """
-    user_id = await get_user_id_from_request(request)
+    user_id = await get_user_id_from_token(request.cookies)
     if not user_id:
        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Unauthorized")
 
@@ -240,7 +240,7 @@ async def dynamic_registration(payload: RegistrationPayload, request: Request):
     """
     # Without authentication this endpoint would let any network-reachable caller
     # use the agent pod as an SSRF proxy to probe internal services.
-    user_id = await get_user_id_from_request(request)
+    user_id = await get_user_id_from_token(request.cookies)
     if not user_id:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Unauthorized")
 

--- a/app/routers/websocket.py
+++ b/app/routers/websocket.py
@@ -21,20 +21,10 @@ from langchain_core.language_models.llms import BaseLanguageModel
 from langchain_core.messages import HumanMessage, ToolMessage
 from langgraph.types import Command
 
-from ..services.auth import get_user_id
+from ..services.auth import get_user_id_from_token
 from ..constants import CONTEXT_PARAMETERS_SUFFIX
 
 router = APIRouter()
-
-async def get_user_id_from_websocket(websocket: WebSocket) -> str:
-    """
-    Retrieves the user ID from the Rancher API using the session token from the WebSocket cookies.
-    """
-    cookies = websocket.cookies
-    rancher_url = os.environ.get("RANCHER_URL","https://rancher.cattle-system")
-    token = os.environ.get("RANCHER_API_TOKEN", cookies.get("R_SESS", ""))
-
-    return await get_user_id(rancher_url, token)
 
 def build_chat_metadata(thread_id: str, agents_metadata: list[dict], websocket: WebSocket) -> str:
     """
@@ -71,7 +61,7 @@ async def websocket_endpoint(websocket: WebSocket, thread_id: str = None, llm: B
     handles the back-and-forth communication with the client.
     """
     
-    user_id = await get_user_id_from_websocket(websocket)
+    user_id = await get_user_id_from_token(websocket.cookies)
     
     if not thread_id:
         thread_id = str(uuid.uuid4())

--- a/app/services/auth.py
+++ b/app/services/auth.py
@@ -3,8 +3,6 @@ import ssl
 import httpx
 import os
 import urllib3
-from urllib.parse import urlparse
-from fastapi import Request
 from typing import cast
 from kubernetes import client, config
 
@@ -130,7 +128,6 @@ async def get_user_id(host: str, token: str) -> str | None:
                 user_id = payload["data"][0]["id"]
 
                 if user_id:
-                    logging.info("user API returned: %s - userId %s", resp.status_code, user_id)
                     return user_id
                 break
         except httpx.ConnectError as e:
@@ -138,7 +135,7 @@ async def get_user_id(host: str, token: str) -> str | None:
                 logging.warning("TLS error connecting to Rancher API, reloading CA certificate and retrying")
                 _reset_cacerts_cache()
                 continue
-            logging.error("user API call failed: %s", e)
+            logging.error("TLS: user API call failed: %s", e)
             break
         except Exception as e:
             logging.error("user API call failed: %s", e)
@@ -146,20 +143,23 @@ async def get_user_id(host: str, token: str) -> str | None:
 
     return None
 
-async def get_user_id_from_request(request: Request) -> str | None:
+async def get_user_id_from_token(cookies) -> str | None:
     """
-    Retrieves the user ID from the Rancher API using the session token from the request cookies.
+    Retrieves the user ID from the Rancher API using the session token extracted
+    from the given cookies, preferring the RANCHER_API_TOKEN env var and falling
+    back to the R_SESS cookie.
     """
+    token = os.environ.get("RANCHER_API_TOKEN", cookies.get("R_SESS", ""))
+    if not token:
+        logging.warning("R_SESS token not found")
+        return None
+    
     rancher_url = os.environ.get("RANCHER_URL", "").strip()
     if not rancher_url:
         rancher_url = _load_rancher_url()
     if not rancher_url:
         logging.error("Rancher URL is not configured and could not be fetched from the cluster")
         return None
-    token = request.cookies.get("R_SESS")
 
-    if not token:
-        logging.warning("R_SESS cookie not found")
-        return None
 
     return await get_user_id(rancher_url, token)

--- a/app/services/auth.py
+++ b/app/services/auth.py
@@ -78,7 +78,7 @@ def _load_rancher_url() -> str | None:
         url: str = result.get("value", "")
         if url:
             _rancher_url = url
-            logging.info("Loaded Rancher URL from internal-server-url setting: %s", url)
+            logging.info("Loaded Rancher URL from internal-server-url setting")
         else:
             logging.warning("internal-server-url setting is empty")
     except Exception as e:

--- a/tests/integration/test_multi_agent.py
+++ b/tests/integration/test_multi_agent.py
@@ -184,7 +184,7 @@ def setup_mock_mcp_servers(module_monkeypatch):
 
     app.memory_manager = MockMemoryManager()
     
-    module_monkeypatch.setattr("app.routers.websocket.get_user_id", AsyncMock(return_value="test-user-id"))
+    module_monkeypatch.setattr("app.routers.websocket.get_user_id_from_token", AsyncMock(return_value="test-user-id"))
     
     # Create multiple agent configs for multi-agent setup
     mock_agent_config_1 = AgentConfig(

--- a/tests/integration/test_single_agent.py
+++ b/tests/integration/test_single_agent.py
@@ -59,7 +59,7 @@ def setup_mock_mcp_server(module_monkeypatch):
 
     app.memory_manager = MockMemoryManager()
     
-    module_monkeypatch.setattr("app.routers.websocket.get_user_id", AsyncMock(return_value="test-user-id"))
+    module_monkeypatch.setattr("app.routers.websocket.get_user_id_from_token", AsyncMock(return_value="test-user-id"))
     
     mock_agent_config = AgentConfig(
         name="test-agent",

--- a/tests/unit/routers/test_chat.py
+++ b/tests/unit/routers/test_chat.py
@@ -18,7 +18,7 @@ async def test_get_chats_success(mock_request):
         {"id": "1", "userId": "u", "createdAt": 2},
         {"id": "2", "userId": "u", "createdAt": 1},
     ]
-    with patch("app.routers.chat.get_user_id_from_request", AsyncMock(return_value="u")):
+    with patch("app.routers.chat.get_user_id_from_token", AsyncMock(return_value="u")):
         resp = await chat_router.get_chats(mock_request)
         assert resp.status_code == status.HTTP_200_OK
         assert resp.body
@@ -29,7 +29,7 @@ async def test_get_chats_sort_asc(mock_request):
         {"id": "1", "userId": "u", "createdAt": 2},
         {"id": "2", "userId": "u", "createdAt": 1},
     ]
-    with patch("app.routers.chat.get_user_id_from_request", AsyncMock(return_value="u")):
+    with patch("app.routers.chat.get_user_id_from_token", AsyncMock(return_value="u")):
         resp = await chat_router.get_chats(mock_request, sort="createdAt:asc")
         result = json.loads(resp.body)
         assert result[0]["createdAt"] == 1
@@ -38,7 +38,7 @@ async def test_get_chats_sort_asc(mock_request):
 @pytest.mark.asyncio
 async def test_get_chat_not_found(mock_request):
     mock_request.app.memory_manager.fetch_chat.return_value = None
-    with patch("app.routers.chat.get_user_id_from_request", AsyncMock(return_value="u")):
+    with patch("app.routers.chat.get_user_id_from_token", AsyncMock(return_value="u")):
         with pytest.raises(HTTPException) as exc:
             await chat_router.get_chat(mock_request, chat_id="notfound")
         assert exc.value.status_code == status.HTTP_404_NOT_FOUND
@@ -47,7 +47,7 @@ async def test_get_chat_not_found(mock_request):
 async def test_update_chat_success(mock_request):
     mock_request.app.memory_manager.fetch_chat.return_value = {"id": "1", "userId": "u"}
     mock_request.app.memory_manager.update_chat.return_value = {"id": "1", "userId": "u", "name": "updated"}
-    with patch("app.routers.chat.get_user_id_from_request", AsyncMock(return_value="u")):
+    with patch("app.routers.chat.get_user_id_from_token", AsyncMock(return_value="u")):
         resp = await chat_router.update_chat(mock_request, chat_id="1", chat_data={"name": "updated"})
         assert resp.status_code == status.HTTP_200_OK
         assert b"updated" in resp.body
@@ -56,7 +56,7 @@ async def test_update_chat_success(mock_request):
 @pytest.mark.asyncio
 async def test_update_chat_not_found(mock_request):
     mock_request.app.memory_manager.fetch_chat.return_value = None
-    with patch("app.routers.chat.get_user_id_from_request", AsyncMock(return_value="u")):
+    with patch("app.routers.chat.get_user_id_from_token", AsyncMock(return_value="u")):
         with pytest.raises(HTTPException) as exc:
             await chat_router.update_chat(mock_request, chat_id="notfound", chat_data={"name": "updated"})
         assert exc.value.status_code == status.HTTP_404_NOT_FOUND
@@ -66,7 +66,7 @@ async def test_update_chat_not_found(mock_request):
 async def test_update_chat_update_failure(mock_request):
     mock_request.app.memory_manager.fetch_chat.return_value = {"id": "1", "userId": "u"}
     mock_request.app.memory_manager.update_chat.return_value = None
-    with patch("app.routers.chat.get_user_id_from_request", AsyncMock(return_value="u")):
+    with patch("app.routers.chat.get_user_id_from_token", AsyncMock(return_value="u")):
         with pytest.raises(HTTPException) as exc:
             await chat_router.update_chat(mock_request, chat_id="1", chat_data={"name": "fail"})
         assert exc.value.status_code == status.HTTP_404_NOT_FOUND
@@ -75,7 +75,7 @@ async def test_update_chat_update_failure(mock_request):
 @pytest.mark.asyncio
 async def test_update_chat_invalid_data(mock_request):
     mock_request.app.memory_manager.fetch_chat.return_value = {"id": "1", "userId": "u"}
-    with patch("app.routers.chat.get_user_id_from_request", AsyncMock(return_value="u")):
+    with patch("app.routers.chat.get_user_id_from_token", AsyncMock(return_value="u")):
         with pytest.raises(Exception):
             await chat_router.update_chat(mock_request, chat_id="1", chat_data=None)
 
@@ -83,14 +83,14 @@ async def test_update_chat_invalid_data(mock_request):
 async def test_delete_chat_success(mock_request):
     mock_request.app.memory_manager.fetch_chat.return_value = {"id": "1", "userId": "u"}
     mock_request.app.memory_manager.delete_chat.return_value = None
-    with patch("app.routers.chat.get_user_id_from_request", AsyncMock(return_value="u")):
+    with patch("app.routers.chat.get_user_id_from_token", AsyncMock(return_value="u")):
         resp = await chat_router.delete_chat(mock_request, chat_id="1")
         assert resp.status_code == status.HTTP_204_NO_CONTENT
 
 @pytest.mark.asyncio
 async def test_get_chat_messages_not_found(mock_request):
     mock_request.app.memory_manager.fetch_chat.return_value = None
-    with patch("app.routers.chat.get_user_id_from_request", AsyncMock(return_value="u")):
+    with patch("app.routers.chat.get_user_id_from_token", AsyncMock(return_value="u")):
         with pytest.raises(HTTPException) as exc:
             await chat_router.get_chat_messages(mock_request, chat_id="notfound")
         assert exc.value.status_code == status.HTTP_404_NOT_FOUND

--- a/tests/unit/routers/test_configuration.py
+++ b/tests/unit/routers/test_configuration.py
@@ -22,7 +22,7 @@ def mock_request():
 @pytest.mark.asyncio
 async def test_get_models_openai_success(mock_request):
     """Test getting OpenAI models successfully."""
-    with patch("app.routers.configuration.get_user_id_from_request", AsyncMock(return_value="test-user")):
+    with patch("app.routers.configuration.get_user_id_from_token", AsyncMock(return_value="test-user")):
         resp = await config_router.get_models(mock_request, llm_name="openai")
         assert resp.status_code == status.HTTP_200_OK
         content = json.loads(resp.body)
@@ -33,7 +33,7 @@ async def test_get_models_openai_success(mock_request):
 @pytest.mark.asyncio
 async def test_get_models_gemini_success(mock_request):
     """Test getting Gemini models successfully."""
-    with patch("app.routers.configuration.get_user_id_from_request", AsyncMock(return_value="test-user")):
+    with patch("app.routers.configuration.get_user_id_from_token", AsyncMock(return_value="test-user")):
         resp = await config_router.get_models(mock_request, llm_name="gemini")
         assert resp.status_code == status.HTTP_200_OK
         content = json.loads(resp.body)
@@ -44,7 +44,7 @@ async def test_get_models_gemini_success(mock_request):
 @pytest.mark.asyncio
 async def test_get_models_unsupported_provider(mock_request):
     """Test getting models for unsupported provider."""
-    with patch("app.routers.configuration.get_user_id_from_request", AsyncMock(return_value="test-user")):
+    with patch("app.routers.configuration.get_user_id_from_token", AsyncMock(return_value="test-user")):
         with pytest.raises(HTTPException) as exc:
             await config_router.get_models(mock_request, llm_name="invalid-provider")
         assert exc.value.status_code == status.HTTP_400_BAD_REQUEST
@@ -53,7 +53,7 @@ async def test_get_models_unsupported_provider(mock_request):
 @pytest.mark.asyncio
 async def test_get_models_unauthorized(mock_request):
     """Test getting models without authentication."""
-    with patch("app.routers.configuration.get_user_id_from_request", AsyncMock(return_value=None)):
+    with patch("app.routers.configuration.get_user_id_from_token", AsyncMock(return_value=None)):
         with pytest.raises(HTTPException) as exc:
             await config_router.get_models(mock_request, llm_name="openai")
         assert exc.value.status_code == status.HTTP_401_UNAUTHORIZED
@@ -62,7 +62,7 @@ async def test_get_models_unauthorized(mock_request):
 @pytest.mark.asyncio
 async def test_get_models_ollama_no_url(mock_request):
     """Test getting Ollama models without URL parameter."""
-    with patch("app.routers.configuration.get_user_id_from_request", AsyncMock(return_value="test-user")):
+    with patch("app.routers.configuration.get_user_id_from_token", AsyncMock(return_value="test-user")):
         with pytest.raises(HTTPException) as exc:
             await config_router.get_models(mock_request, llm_name="ollama")
         assert exc.value.status_code == status.HTTP_400_BAD_REQUEST
@@ -85,7 +85,7 @@ async def test_get_models_ollama_success(mock_request):
     mock_http_client = AsyncMock()
     mock_http_client.get = AsyncMock(return_value=mock_response)
     
-    with patch("app.routers.configuration.get_user_id_from_request", AsyncMock(return_value="test-user")):
+    with patch("app.routers.configuration.get_user_id_from_token", AsyncMock(return_value="test-user")):
         with patch("httpx.AsyncClient") as mock_client_class:
             mock_client_class.return_value.__aenter__ = AsyncMock(return_value=mock_http_client)
             mock_client_class.return_value.__aexit__ = AsyncMock(return_value=None)
@@ -105,7 +105,7 @@ async def test_get_models_ollama_connection_error(mock_request):
     mock_http_client = AsyncMock()
     mock_http_client.get = AsyncMock(side_effect=httpx.RequestError("Connection failed"))
     
-    with patch("app.routers.configuration.get_user_id_from_request", AsyncMock(return_value="test-user")):
+    with patch("app.routers.configuration.get_user_id_from_token", AsyncMock(return_value="test-user")):
         with patch("httpx.AsyncClient") as mock_client_class:
             mock_client_class.return_value.__aenter__ = AsyncMock(return_value=mock_http_client)
             mock_client_class.return_value.__aexit__ = AsyncMock(return_value=None)
@@ -125,7 +125,7 @@ async def test_get_models_ollama_bad_status(mock_request):
     mock_http_client = AsyncMock()
     mock_http_client.get = AsyncMock(return_value=mock_response)
     
-    with patch("app.routers.configuration.get_user_id_from_request", AsyncMock(return_value="test-user")):
+    with patch("app.routers.configuration.get_user_id_from_token", AsyncMock(return_value="test-user")):
         with patch("httpx.AsyncClient") as mock_client_class:
             mock_client_class.return_value.__aenter__ = AsyncMock(return_value=mock_http_client)
             mock_client_class.return_value.__aexit__ = AsyncMock(return_value=None)
@@ -141,7 +141,7 @@ async def test_get_models_ollama_malformed_url(mock_request):
     
     import httpx
     
-    with patch("app.routers.configuration.get_user_id_from_request", AsyncMock(return_value="test-user")):
+    with patch("app.routers.configuration.get_user_id_from_token", AsyncMock(return_value="test-user")):
         with patch("httpx.AsyncClient") as mock_client_class:
             mock_http_client = AsyncMock()
             mock_http_client.get = AsyncMock(side_effect=httpx.InvalidURL("Invalid port in URL"))
@@ -158,7 +158,7 @@ async def test_get_models_bedrock_missing_region(mock_request):
     """Test getting Bedrock models without region parameter."""
     mock_request.query_params = {"bearerToken": "test-token"}
     
-    with patch("app.routers.configuration.get_user_id_from_request", AsyncMock(return_value="test-user")):
+    with patch("app.routers.configuration.get_user_id_from_token", AsyncMock(return_value="test-user")):
         with pytest.raises(HTTPException) as exc:
             await config_router.get_models(mock_request, llm_name="bedrock")
         assert exc.value.status_code == status.HTTP_400_BAD_REQUEST
@@ -169,7 +169,7 @@ async def test_get_models_bedrock_missing_credentials(mock_request):
     """Test getting Bedrock models without bearer token."""
     mock_request.query_params = {"region": "us-east-1"}
     
-    with patch("app.routers.configuration.get_user_id_from_request", AsyncMock(return_value="test-user")):
+    with patch("app.routers.configuration.get_user_id_from_token", AsyncMock(return_value="test-user")):
         with pytest.raises(HTTPException) as exc:
             await config_router.get_models(mock_request, llm_name="bedrock")
         assert exc.value.status_code == status.HTTP_400_BAD_REQUEST
@@ -195,7 +195,7 @@ async def test_get_models_bedrock_bearer_token_success(mock_request):
     mock_http_client = AsyncMock()
     mock_http_client.get = AsyncMock(return_value=mock_response)
     
-    with patch("app.routers.configuration.get_user_id_from_request", AsyncMock(return_value="test-user")):
+    with patch("app.routers.configuration.get_user_id_from_token", AsyncMock(return_value="test-user")):
         with patch("httpx.AsyncClient") as mock_client_class:
             mock_client_class.return_value.__aenter__ = AsyncMock(return_value=mock_http_client)
             mock_client_class.return_value.__aexit__ = AsyncMock(return_value=None)
@@ -226,7 +226,7 @@ async def test_get_models_bedrock_bearer_token_invalid(mock_request):
     mock_http_client = AsyncMock()
     mock_http_client.get = AsyncMock(return_value=mock_response)
     
-    with patch("app.routers.configuration.get_user_id_from_request", AsyncMock(return_value="test-user")):
+    with patch("app.routers.configuration.get_user_id_from_token", AsyncMock(return_value="test-user")):
         with patch("httpx.AsyncClient") as mock_client_class:
             mock_client_class.return_value.__aenter__ = AsyncMock(return_value=mock_http_client)
             mock_client_class.return_value.__aexit__ = AsyncMock(return_value=None)
@@ -256,7 +256,7 @@ async def test_get_models_bedrock_with_openai_models(mock_request):
     mock_http_client = AsyncMock()
     mock_http_client.get = AsyncMock(return_value=mock_response)
     
-    with patch("app.routers.configuration.get_user_id_from_request", AsyncMock(return_value="test-user")):
+    with patch("app.routers.configuration.get_user_id_from_token", AsyncMock(return_value="test-user")):
         with patch("httpx.AsyncClient") as mock_client_class:
             mock_client_class.return_value.__aenter__ = AsyncMock(return_value=mock_http_client)
             mock_client_class.return_value.__aexit__ = AsyncMock(return_value=None)
@@ -292,7 +292,7 @@ async def test_get_models_bedrock_with_already_prefixed_models(mock_request):
     mock_http_client = AsyncMock()
     mock_http_client.get = AsyncMock(return_value=mock_response)
     
-    with patch("app.routers.configuration.get_user_id_from_request", AsyncMock(return_value="test-user")):
+    with patch("app.routers.configuration.get_user_id_from_token", AsyncMock(return_value="test-user")):
         with patch("httpx.AsyncClient") as mock_client_class:
             mock_client_class.return_value.__aenter__ = AsyncMock(return_value=mock_http_client)
             mock_client_class.return_value.__aexit__ = AsyncMock(return_value=None)
@@ -310,7 +310,7 @@ async def test_get_models_bedrock_with_already_prefixed_models(mock_request):
 @pytest.mark.asyncio
 async def test_get_settings_success(mock_request):
     """Test getting settings successfully."""
-    with patch("app.routers.configuration.get_user_id_from_request", AsyncMock(return_value="test-user")):
+    with patch("app.routers.configuration.get_user_id_from_token", AsyncMock(return_value="test-user")):
         resp = await config_router.get_settings(mock_request)
         assert resp.status_code == status.HTTP_200_OK
         content = json.loads(resp.body)
@@ -321,7 +321,7 @@ async def test_get_settings_success(mock_request):
 @pytest.mark.asyncio
 async def test_get_settings_unauthorized(mock_request):
     """Test getting settings without authentication."""
-    with patch("app.routers.configuration.get_user_id_from_request", AsyncMock(return_value=None)):
+    with patch("app.routers.configuration.get_user_id_from_token", AsyncMock(return_value=None)):
         with pytest.raises(HTTPException) as exc:
             await config_router.get_settings(mock_request)
         assert exc.value.status_code == status.HTTP_401_UNAUTHORIZED
@@ -331,7 +331,7 @@ async def test_get_settings_unauthorized(mock_request):
 async def test_update_settings_unauthorized(mock_request):
     """Test updating settings without authentication."""
     settings = SettingsUpdate(OPENAI_API_KEY="test-key")
-    with patch("app.routers.configuration.get_user_id_from_request", AsyncMock(return_value=None)):
+    with patch("app.routers.configuration.get_user_id_from_token", AsyncMock(return_value=None)):
         with pytest.raises(HTTPException) as exc:
             await config_router.update_settings(settings, mock_request)
         assert exc.value.status_code == status.HTTP_401_UNAUTHORIZED
@@ -341,7 +341,7 @@ async def test_update_settings_unauthorized(mock_request):
 async def test_update_settings_permission_denied(mock_request):
     """Test updating settings without permission."""
     settings = SettingsUpdate(OPENAI_API_KEY="test-key")
-    with patch("app.routers.configuration.get_user_id_from_request", AsyncMock(return_value="test-user")):
+    with patch("app.routers.configuration.get_user_id_from_token", AsyncMock(return_value="test-user")):
         with patch("app.routers.configuration.check_k8s_permission", AsyncMock(return_value=False)):
             resp = await config_router.update_settings(settings, mock_request)
             assert resp.status_code == status.HTTP_403_FORBIDDEN
@@ -369,7 +369,7 @@ async def test_update_settings_success(mock_request):
         "OPENAI_MODEL": "gpt-3.5-turbo",
     }
     
-    with patch("app.routers.configuration.get_user_id_from_request", AsyncMock(return_value="test-user")):
+    with patch("app.routers.configuration.get_user_id_from_token", AsyncMock(return_value="test-user")):
         with patch("app.routers.configuration.check_k8s_permission", AsyncMock(return_value=True)):
             with patch("app.routers.configuration.k8s_config.load_incluster_config"):
                 with patch("app.routers.configuration.client.CoreV1Api") as mock_api:
@@ -392,7 +392,7 @@ async def test_update_settings_k8s_error(mock_request):
     """Test updating settings with Kubernetes API error."""
     settings = SettingsUpdate(OPENAI_API_KEY="test-key")
     
-    with patch("app.routers.configuration.get_user_id_from_request", AsyncMock(return_value="test-user")):
+    with patch("app.routers.configuration.get_user_id_from_token", AsyncMock(return_value="test-user")):
         with patch("app.routers.configuration.check_k8s_permission", AsyncMock(return_value=True)):
             with patch("app.routers.configuration.k8s_config.load_incluster_config"):
                 with patch("app.routers.configuration.client.CoreV1Api") as mock_api:
@@ -428,7 +428,7 @@ async def test_update_settings_partial_fields(mock_request):
         "ACTIVE_LLM": "gemini",
     }
     
-    with patch("app.routers.configuration.get_user_id_from_request", AsyncMock(return_value="test-user")):
+    with patch("app.routers.configuration.get_user_id_from_token", AsyncMock(return_value="test-user")):
         with patch("app.routers.configuration.check_k8s_permission", AsyncMock(return_value=True)):
             with patch("app.routers.configuration.k8s_config.load_incluster_config"):
                 with patch("app.routers.configuration.client.CoreV1Api") as mock_api:
@@ -460,7 +460,7 @@ async def test_update_settings_nonexistent_field(mock_request):
     mock_configmap = MagicMock()
     mock_configmap.data = {}
     
-    with patch("app.routers.configuration.get_user_id_from_request", AsyncMock(return_value="test-user")):
+    with patch("app.routers.configuration.get_user_id_from_token", AsyncMock(return_value="test-user")):
         with patch("app.routers.configuration.check_k8s_permission", AsyncMock(return_value=True)):
             with patch("app.routers.configuration.k8s_config.load_incluster_config"):
                 with patch("app.routers.configuration.client.CoreV1Api") as mock_api:
@@ -482,7 +482,7 @@ async def test_update_settings_validate_ollama(mock_request):
     """Test validation when ACTIVE_LLM is set to ollama."""
     settings = SettingsUpdate(ACTIVE_LLM="ollama")
     
-    with patch("app.routers.configuration.get_user_id_from_request", AsyncMock(return_value="test-user")):
+    with patch("app.routers.configuration.get_user_id_from_token", AsyncMock(return_value="test-user")):
         with patch("app.routers.configuration.check_k8s_permission", AsyncMock(return_value=True)):
             resp = await config_router.update_settings(settings, mock_request)
             assert resp.status_code == status.HTTP_400_BAD_REQUEST
@@ -495,7 +495,7 @@ async def test_update_settings_validate_invalid_llm(mock_request):
     """Test validation when ACTIVE_LLM is set to an invalid value."""
     settings = SettingsUpdate(ACTIVE_LLM="invalid-llm")
     
-    with patch("app.routers.configuration.get_user_id_from_request", AsyncMock(return_value="test-user")):
+    with patch("app.routers.configuration.get_user_id_from_token", AsyncMock(return_value="test-user")):
         with patch("app.routers.configuration.check_k8s_permission", AsyncMock(return_value=True)):
             resp = await config_router.update_settings(settings, mock_request)
             assert resp.status_code == status.HTTP_400_BAD_REQUEST
@@ -525,7 +525,7 @@ async def test_update_settings_validate_ollama_success(mock_request):
         "ACTIVE_LLM": "gemini"
     }
     
-    with patch("app.routers.configuration.get_user_id_from_request", AsyncMock(return_value="test-user")):
+    with patch("app.routers.configuration.get_user_id_from_token", AsyncMock(return_value="test-user")):
         with patch("app.routers.configuration.check_k8s_permission", AsyncMock(return_value=True)):
             with patch("app.routers.configuration.k8s_config.load_incluster_config"):
                 with patch("app.routers.configuration.client.CoreV1Api") as mock_api:
@@ -543,7 +543,7 @@ async def test_update_settings_validate_bedrock_missing_region(mock_request):
     """Test validation when ACTIVE_LLM is bedrock without region."""
     settings = SettingsUpdate(ACTIVE_LLM="bedrock", BEDROCK_MODEL="claude-opus")
     
-    with patch("app.routers.configuration.get_user_id_from_request", AsyncMock(return_value="test-user")):
+    with patch("app.routers.configuration.get_user_id_from_token", AsyncMock(return_value="test-user")):
         with patch("app.routers.configuration.check_k8s_permission", AsyncMock(return_value=True)):
             resp = await config_router.update_settings(settings, mock_request)
             assert resp.status_code == status.HTTP_400_BAD_REQUEST
@@ -560,7 +560,7 @@ async def test_update_settings_validate_bedrock_missing_auth(mock_request):
         BEDROCK_MODEL="claude-opus"
     )
     
-    with patch("app.routers.configuration.get_user_id_from_request", AsyncMock(return_value="test-user")):
+    with patch("app.routers.configuration.get_user_id_from_token", AsyncMock(return_value="test-user")):
         with patch("app.routers.configuration.check_k8s_permission", AsyncMock(return_value=True)):
             resp = await config_router.update_settings(settings, mock_request)
             assert resp.status_code == status.HTTP_400_BAD_REQUEST
@@ -590,7 +590,7 @@ async def test_update_settings_validate_bedrock_with_bearer_token(mock_request):
         "ACTIVE_LLM": "openai"
     }
     
-    with patch("app.routers.configuration.get_user_id_from_request", AsyncMock(return_value="test-user")):
+    with patch("app.routers.configuration.get_user_id_from_token", AsyncMock(return_value="test-user")):
         with patch("app.routers.configuration.check_k8s_permission", AsyncMock(return_value=True)):
             with patch("app.routers.configuration.k8s_config.load_incluster_config"):
                 with patch("app.routers.configuration.client.CoreV1Api") as mock_api:
@@ -608,7 +608,7 @@ async def test_update_settings_validate_openai(mock_request):
     """Test validation when ACTIVE_LLM is openai."""
     settings = SettingsUpdate(ACTIVE_LLM="openai", OPENAI_MODEL="gpt-4")
     
-    with patch("app.routers.configuration.get_user_id_from_request", AsyncMock(return_value="test-user")):
+    with patch("app.routers.configuration.get_user_id_from_token", AsyncMock(return_value="test-user")):
         with patch("app.routers.configuration.check_k8s_permission", AsyncMock(return_value=True)):
             resp = await config_router.update_settings(settings, mock_request)
             assert resp.status_code == status.HTTP_400_BAD_REQUEST
@@ -621,7 +621,7 @@ async def test_update_settings_validate_gemini(mock_request):
     """Test validation when ACTIVE_LLM is gemini."""
     settings = SettingsUpdate(ACTIVE_LLM="gemini", GEMINI_MODEL="gemini-2.0-flash")
     
-    with patch("app.routers.configuration.get_user_id_from_request", AsyncMock(return_value="test-user")):
+    with patch("app.routers.configuration.get_user_id_from_token", AsyncMock(return_value="test-user")):
         with patch("app.routers.configuration.check_k8s_permission", AsyncMock(return_value=True)):
             resp = await config_router.update_settings(settings, mock_request)
             assert resp.status_code == status.HTTP_400_BAD_REQUEST
@@ -633,7 +633,7 @@ async def test_update_settings_validate_generic_openai(mock_request):
     """Test validation when ACTIVE_LLM is generic-openai."""
     settings = SettingsUpdate(ACTIVE_LLM="generic-openai", GENERIC_OPENAI_MODEL="gpt-4")
     
-    with patch("app.routers.configuration.get_user_id_from_request", AsyncMock(return_value="test-user")):
+    with patch("app.routers.configuration.get_user_id_from_token", AsyncMock(return_value="test-user")):
         with patch("app.routers.configuration.check_k8s_permission", AsyncMock(return_value=True)):
             resp = await config_router.update_settings(settings, mock_request)
             assert resp.status_code == status.HTTP_400_BAD_REQUEST

--- a/tests/unit/routers/test_router_llm.py
+++ b/tests/unit/routers/test_router_llm.py
@@ -17,7 +17,7 @@ async def test_complete_ui_tools_success(mock_request):
     mock_selector = MagicMock()
     mock_selector.select_tools = AsyncMock(return_value=[{"toolName": "show"}])
     
-    with patch("app.routers.llm.get_user_id_from_request", AsyncMock(return_value="u")):
+    with patch("app.routers.llm.get_user_id_from_token", AsyncMock(return_value="u")):
         ui_tools_config = llm_router.UIToolsConfig(name="tools", tools=["show"])
         ui_tools_request = llm_router.UIToolsRequest(
             prompt="test",
@@ -31,7 +31,7 @@ async def test_complete_ui_tools_success(mock_request):
 
 @pytest.mark.asyncio
 async def test_complete_ui_tools_missing_name(mock_request):    
-    with patch("app.routers.llm.get_user_id_from_request", AsyncMock(return_value="u")):
+    with patch("app.routers.llm.get_user_id_from_token", AsyncMock(return_value="u")):
         ui_tools_config = llm_router.UIToolsConfig(name="", tools=None)
         ui_tools_request = llm_router.UIToolsRequest(
             prompt="test",

--- a/tests/unit/routers/test_websocket.py
+++ b/tests/unit/routers/test_websocket.py
@@ -59,7 +59,7 @@ class MockWebSocket:
 def mock_dependencies():
     with patch('app.routers.websocket.build_agent', new_callable=AsyncMock) as mock_build_agent, \
          patch('app.routers.websocket._call_agent', new_callable=AsyncMock) as mock_call_agent, \
-         patch('app.routers.websocket.get_user_id_from_websocket', new_callable=AsyncMock) as mock_get_user_id:
+         patch('app.routers.websocket.get_user_id_from_token', new_callable=AsyncMock) as mock_get_user_id:
 
         mock_agent = MagicMock()
         mock_agent.aget_state = AsyncMock(return_value=MagicMock(interrupts=[]))

--- a/tests/unit/services/test_auth.py
+++ b/tests/unit/services/test_auth.py
@@ -14,7 +14,7 @@ from app.services.auth import (
     _is_tls_error,
     _get_tls_verify,
     get_user_id,
-    get_user_id_from_request,
+    get_user_id_from_token,
 )
 
 SAMPLE_CA_PEM = """\
@@ -398,55 +398,53 @@ class TestGetUserId:
 
 
 # ---------------------------------------------------------------------------
-# get_user_id_from_request
+# get_user_id_from_token
 # ---------------------------------------------------------------------------
 
-class TestGetUserIdFromRequest:
+class TestGetUserIdFromToken:
     @pytest.mark.asyncio
-    async def test_returns_none_when_no_r_sess_cookie(self):
-        mock_request = MagicMock()
-        mock_request.cookies.get.return_value = None
-        result = await get_user_id_from_request(mock_request)
+    async def test_returns_none_when_no_token(self):
+        with patch.dict(os.environ, {}, clear=True):
+            result = await get_user_id_from_token({})
         assert result is None
 
     @pytest.mark.asyncio
     async def test_delegates_to_get_user_id(self):
-        mock_request = MagicMock()
-        mock_request.cookies.get.return_value = "my-session-token"
         with patch.dict(os.environ, {"RANCHER_URL": "https://rancher.example.com"}), \
              patch("app.services.auth.get_user_id", new=AsyncMock(return_value="user-789")) as mock_get:
-            result = await get_user_id_from_request(mock_request)
+            result = await get_user_id_from_token({"R_SESS": "my-session-token"})
         mock_get.assert_called_once_with("https://rancher.example.com", "my-session-token")
         assert result == "user-789"
 
     @pytest.mark.asyncio
+    async def test_api_token_env_takes_precedence_over_cookie(self):
+        with patch.dict(os.environ, {"RANCHER_URL": "https://rancher.example.com", "RANCHER_API_TOKEN": "env-token"}), \
+             patch("app.services.auth.get_user_id", new=AsyncMock(return_value="user-789")) as mock_get:
+            await get_user_id_from_token({"R_SESS": "cookie-token"})
+        mock_get.assert_called_once_with("https://rancher.example.com", "env-token")
+
+    @pytest.mark.asyncio
     async def test_returns_none_when_cluster_lookup_fails(self):
-        mock_request = MagicMock()
-        mock_request.cookies.get.return_value = "token"
         with patch.dict(os.environ, {}, clear=True), \
              patch("app.services.auth._load_rancher_url", return_value=None), \
              patch("app.services.auth.get_user_id", new=AsyncMock()) as mock_get:
-            result = await get_user_id_from_request(mock_request)
+            result = await get_user_id_from_token({"R_SESS": "token"})
         assert result is None
         mock_get.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_uses_rancher_url_from_cluster_when_env_not_set(self):
-        mock_request = MagicMock()
-        mock_request.cookies.get.return_value = "token"
         with patch.dict(os.environ, {}, clear=True), \
              patch("app.services.auth._load_rancher_url", return_value="https://10.43.31.188"), \
              patch("app.services.auth.get_user_id", new=AsyncMock(return_value="user-001")) as mock_get:
-            await get_user_id_from_request(mock_request)
+            await get_user_id_from_token({"R_SESS": "token"})
         mock_get.assert_called_once_with("https://10.43.31.188", "token")
 
     @pytest.mark.asyncio
     async def test_env_var_takes_precedence_over_cluster_url(self):
-        mock_request = MagicMock()
-        mock_request.cookies.get.return_value = "token"
         with patch.dict(os.environ, {"RANCHER_URL": "https://rancher.example.com"}), \
              patch("app.services.auth._load_rancher_url") as mock_load, \
              patch("app.services.auth.get_user_id", new=AsyncMock(return_value="user-002")) as mock_get:
-            await get_user_id_from_request(mock_request)
+            await get_user_id_from_token({"R_SESS": "token"})
         mock_load.assert_not_called()
         mock_get.assert_called_once_with("https://rancher.example.com", "token")


### PR DESCRIPTION
## Issue https://github.com/rancher/rancher-ai-agent/issues/326

## Problem

`get_user_id_from_websocket` was not fetching the `internal-url` from the `internal-server-url` `setting`, that was causing the agent to fail to get the user id. This was implemented in https://github.com/rancher/rancher-ai-agent/pull/273, but we missed to do it in `get_user_id_from_websocket` too.
This logic to fetch the `internal-server-url` was implemented only for the `get_user_id_from_request` func.

## Solution

Remove `get_user_id_from_websocket`, and refactor `get_user_id_from_request` so it accepts a cookies dict. That way we can use it from the websocket too