### PR TITLE
Add HTTP_PROXY, HTTPS_PROXY and NO_PROXY

### DIFF
--- a/chart/agent/templates/ai-agent-deployment.yaml
+++ b/chart/agent/templates/ai-agent-deployment.yaml
@@ -164,6 +164,24 @@ spec:
             value: "{{ .Values.llmMock.enabled }}"
           - name: LLM_MOCK_URL
             value: "{{ .Values.llmMock.url }}"
+          {{- if .Values.proxy.httpProxy }}
+          - name: HTTP_PROXY
+            value: "{{ .Values.proxy.httpProxy }}"
+          - name: http_proxy
+            value: "{{ .Values.proxy.httpProxy }}"
+          {{- end }}
+          {{- if .Values.proxy.httpsProxy }}
+          - name: HTTPS_PROXY
+            value: "{{ .Values.proxy.httpsProxy }}"
+          - name: https_proxy
+            value: "{{ .Values.proxy.httpsProxy }}"
+          {{- end }}
+          {{- if .Values.proxy.noProxy }}
+          - name: NO_PROXY
+            value: "{{ .Values.proxy.noProxy }}"
+          - name: no_proxy
+            value: "{{ .Values.proxy.noProxy }}"
+          {{- end }}
         ports:
          - containerPort: 8000
         startupProbe:

--- a/chart/agent/templates/mcp-deployment.yaml
+++ b/chart/agent/templates/mcp-deployment.yaml
@@ -47,6 +47,25 @@ spec:
           capabilities:
             drop:
               - ALL
+        env:
+          {{- if .Values.proxy.httpProxy }}
+          - name: HTTP_PROXY
+            value: "{{ .Values.proxy.httpProxy }}"
+          - name: http_proxy
+            value: "{{ .Values.proxy.httpProxy }}"
+          {{- end }}
+          {{- if .Values.proxy.httpsProxy }}
+          - name: HTTPS_PROXY
+            value: "{{ .Values.proxy.httpsProxy }}"
+          - name: https_proxy
+            value: "{{ .Values.proxy.httpsProxy }}"
+          {{- end }}
+          {{- if .Values.proxy.noProxy }}
+          - name: NO_PROXY
+            value: "{{ .Values.proxy.noProxy }}"
+          - name: no_proxy
+            value: "{{ .Values.proxy.noProxy }}"
+          {{- end }}
         ports:
           - containerPort: 9092
         command: ["/usr/local/bin/mcp"]

--- a/chart/agent/values.yaml
+++ b/chart/agent/values.yaml
@@ -51,6 +51,10 @@ probes:
     timeoutSeconds: 5
     failureThreshold: 2
 insecureSkipTls: false
+proxy:
+  httpProxy: ""
+  httpsProxy: ""
+  noProxy: ""
 seLinux:
   enabled: false
 llmMock:


### PR DESCRIPTION
## issue https://github.com/rancher/rancher-ai-agent/issues/208

Add `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY` environment variables to the AI agent and MCP deployments, configurable via `values.yaml`